### PR TITLE
Fix compilation errors caused by old compilers' support for language and library features.

### DIFF
--- a/src/renderer/human_renderer.cpp
+++ b/src/renderer/human_renderer.cpp
@@ -950,7 +950,8 @@ struct AnnotatedLine {
                 unsigned const label_line_beg = level_line_nums[annotation.render_level];
 
                 // Render the label line by line.
-                for (unsigned const line_idx : std::views::iota(0zu, annotation.label.size())) {
+                for (unsigned const line_idx :
+                     std::views::iota(std::size_t(0), annotation.label.size())) {
                     // The target for the `line_idx` line of the label.
                     StyledString& target_line = rendered_lines[label_line_beg + line_idx];
                     // The content of the `line_idx` line of the label.

--- a/src/renderer/human_renderer.cpp
+++ b/src/renderer/human_renderer.cpp
@@ -868,24 +868,39 @@ struct AnnotatedLine {
                     // 123 |      func(args)
                     //     |  ________^
                     //     | |                  <-- Starting position
-                    return std::span(rendered_lines)
+                    //
+                    // Note that before P1739R4, providing `std::views::drop` with `std::span` would
+                    // result in `std::ranges::drop_view` rather than `std::span`, causing
+                    // inconsistent return types in some compilers (like g++-11) within this lambda
+                    // expression's branches. Therefore, we supply `drop_view` as an argument to
+                    // `std::span`.
+                    return std::span(
+                        rendered_lines
                         | std::views::drop(
-                               annotation.render_level == 0
-                                   ? 1
-                                   : level_line_nums[annotation.render_level]
-                        );
+                            annotation.render_level == 0 ? 1
+                                                         : level_line_nums[annotation.render_level]
+                        )
+                    );
                 case Annotation::MultilineTail:
                     // For the tail, it should start from the first line of `rendered_lines` and
                     // connect to the line where the horizontal connecting line is located.
                     //
                     // 123 | |    func(args)
                     //     | |________^         <-- Ending position
-                    return std::span(rendered_lines)
+                    //
+                    // Note that before P1739R4, providing `std::views::take` with `std::span` would
+                    // result in `std::ranges::take_view` rather than `std::span`, causing
+                    // inconsistent return types in some compilers (like g++-11) within this lambda
+                    // expression's branches. Therefore, we supply `take_view` as an argument to
+                    // `std::span`.
+                    return std::span(
+                        rendered_lines
                         | std::views::take(
-                               annotation.render_level == 0
-                                   ? 0
-                                   : level_line_nums[annotation.render_level] - 1
-                        );
+                            annotation.render_level == 0
+                                ? 0
+                                : level_line_nums[annotation.render_level] - 1
+                        )
+                    );
                 case Annotation::MultilineBody:
                     // For the body of multiline annotations, it should traverse all lines.
                     return std::span(rendered_lines);

--- a/src/renderer/human_renderer.cpp
+++ b/src/renderer/human_renderer.cpp
@@ -74,6 +74,26 @@ auto HumanRenderer::compute_max_line_num_len(AnnotatedSource const& source) cons
     return compute_digits_num(result + source.first_line_number());
 }
 
+namespace detail {
+namespace {
+#ifdef __cpp_lib_unreachable
+using std::unreachable;
+#else
+/// `std::unreachable()` implementation from
+/// [cppreference](https://en.cppreference.com/w/cpp/utility/unreachable).
+[[noreturn]] constexpr void unreachable() {
+    // Uses compiler specific extensions if possible. Even if no extension is used, undefined
+    // behavior is still raised by an empty function body and the noreturn attribute.
+    #if defined(_MSC_VER) && !defined(__clang__)  // MSVC
+    __assume(false);
+    #else  // GCC, Clang
+    __builtin_unreachable();
+    #endif
+}
+#endif
+}  // namespace
+}  // namespace detail
+
 namespace {
 /// Renders a multi-line message `message` with indentation `indentation` onto `render_target`. The
 /// first line of `message` will continue directly from the existing content in `render_target`,
@@ -231,7 +251,7 @@ void render_line_number(
         render_target.append_spaces(1);
         break;
     default:
-        std::unreachable();
+        detail::unreachable();
     }
 
     render_target.append("|", ants::Style::LineNumber);
@@ -596,7 +616,7 @@ struct Annotation {
                 case HumanRenderer::Right:
                     return underline_end - 1;
                 default:
-                    std::unreachable();
+                    detail::unreachable();
                 }
             }
         }();


### PR DESCRIPTION
### Changes:

1. Library Feature Detection for `std::unreachable()`:
   + Add a check to determine if the current compiler supports `std::unreachable()`.
   + Implement a custom `unreachable()` function to be used as a fallback when the compiler doesn't support the standard version.
2. Literal Suffix Compatibility Fix:
   + Replace the literal `0zu` with `std::size_t(0)` to solve the compatibility issues with MSVC, which does not recognize the `zu` suffix.
3. Modification involving `std::views::drop` and `std::views::take`:
   + Modify the parameters of `std::views::drop` and `std::views::take` from `std::span` to its underlying range to address a lack of implementation of P1739R4 in g++-11. Otherwise it will produce `std::ranges::drop_view/take_view` rather than `std::span`.