### PR TITLE
(ci) Optimize Xcode version handling in `gtest.yml` with dynamic setup.

### DIFF
--- a/.github/workflows/gtest.yml
+++ b/.github/workflows/gtest.yml
@@ -66,8 +66,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set Xcode version
-        run: sudo xcode-select --switch /Applications/Xcode_16_beta_5.app
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          # FIXME: Use `latest` instead of `latest-stable` to use the latest beta version of Xcode,
+          # as Xcode 16 is a beta version on `macos-14`.
+          # TODO: Change this to a fixed version of Xcode when the GitHub Actions environment is
+          # updated.
+          xcode-version: latest
 
       - name: Configure CMake
         run: |


### PR DESCRIPTION
- Use `maxim-lobanov/setup-xcode@v1` in `gtest.yml` to switch to the latest available Xcode version on `macos-14`.
- This change addresses the issue of intermittent failures in GitHub Actions due to non-fixed Xcode version names.