### PR TITLE
Implement Colored Output for Diagnostic Information Rendering

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -38,12 +38,14 @@ EmptyLineAfterAccessModifier: Never
 EmptyLineBeforeAccessModifier: Leave
 FixNamespaceComments: true
 IncludeCategories:
-  - Regex:           '^".*\.hpp"' # User Headers
-    Priority:        1
-  - Regex:           '^((<|")(gtest|gmock)/)' # GoogleTest Headers
-    Priority:        2
-  - Regex:           '^<[^>]*>$' # STL Headers
-    Priority:        3
+  - Regex:    '<rang\.hpp>|"rang\.hpp"' # rang.hpp
+    Priority: 2
+  - Regex:    '^((<|")(gtest|gmock)/)' # GoogleTest Headers
+    Priority: 3
+  - Regex:    '^".*\.hpp"' # User Headers
+    Priority: 1
+  - Regex:    '^<[^>]*>$' # STL Headers
+    Priority: 4
 IncludeBlocks: Regroup
 IndentAccessModifiers: false
 IndentCaseBlocks: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,8 @@ option(INSTALL_ANNOTATE_SNIPPETS "Enable installation of the annotate-snippets p
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+include(AddRang)
+
 add_library(annotate_snippets
     src/annotated_source.cpp
     src/detail/styled_string_impl.cpp
@@ -52,6 +54,8 @@ target_compile_options(annotate_snippets
         $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
 )
 
+target_link_libraries(annotate_snippets PRIVATE rang::rang)
+
 add_library(ants::annotate_snippets ALIAS annotate_snippets)
 
 if (ANNOTATE_SNIPPETS_ENABLE_TESTING)
@@ -63,7 +67,7 @@ if (INSTALL_ANNOTATE_SNIPPETS)
     set(ANNOTATE_SNIPPETS_CMAKE_INSTALL_PATH "${CMAKE_INSTALL_LIBDIR}/cmake/annotate-snippets")
 
     # Installation setup
-    install(TARGETS annotate_snippets
+    install(TARGETS annotate_snippets rang
         EXPORT annotate-snippets-targets
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ include(AddRang)
 
 add_library(annotate_snippets
     src/annotated_source.cpp
+    src/style_spec.cpp
     src/detail/styled_string_impl.cpp
     src/renderer/human_renderer.cpp
 )

--- a/cmake/AddRang.cmake
+++ b/cmake/AddRang.cmake
@@ -1,0 +1,27 @@
+if (NOT DEFINED RANG_PATH)
+    set(RANG_PATH "${CMAKE_SOURCE_DIR}/rang")
+endif()
+
+message(STATUS "Looking for rang sources in ${RANG_PATH}")
+
+if (EXISTS "${RANG_PATH}" AND IS_DIRECTORY "${RANG_PATH}" AND EXISTS "${RANG_PATH}/CMakeLists.txt")
+    message(STATUS "Found rang sources in ${RANG_PATH}")
+    add_subdirectory(${RANG_PATH})
+else()
+    message(STATUS "Did not find rang sources. Fetching from GitHub...")
+
+    include(FetchContent)
+    FetchContent_Declare(
+        rang
+        # rang release 3.2
+        URL https://github.com/agauniyal/rang/archive/refs/tags/v3.2.zip
+        URL_HASH MD5=AC7B6EAC8E42F0E434F4B60C8FD7C22C
+    )
+
+    FetchContent_MakeAvailable(rang)
+endif()
+
+if (TARGET rang AND NOT TARGET rang::rang)
+    message(STATUS "Creating alias target rang::rang")
+    add_library(rang::rang ALIAS rang)
+endif()

--- a/include/annotate_snippets/renderer/human_renderer.hpp
+++ b/include/annotate_snippets/renderer/human_renderer.hpp
@@ -6,6 +6,7 @@
 #include "annotate_snippets/detail/diag/level.hpp"
 #include "annotate_snippets/detail/styled_string_impl.hpp"
 #include "annotate_snippets/diag.hpp"
+#include "annotate_snippets/style.hpp"
 #include "annotate_snippets/style_spec.hpp"
 #include "annotate_snippets/styled_string.hpp"
 #include "annotate_snippets/styled_string_view.hpp"
@@ -244,7 +245,9 @@ public:
                 // always used.
                 StyleSpec const spec = part.style == Style::Default
                     ? StyleSpec()
-                    : std::invoke_r<StyleSpec>(style_sheet, part.style, diag_entry.level());
+                    : static_cast<StyleSpec>(
+                          std::invoke(style_sheet, part.style, diag_entry.level())
+                      );
 
                 spec.render_string(out, part.content);
             }

--- a/include/annotate_snippets/style_spec.hpp
+++ b/include/annotate_snippets/style_spec.hpp
@@ -1,0 +1,200 @@
+#ifndef ANNOTATE_SNIPPETS_STYLE_SPEC_HPP
+#define ANNOTATE_SNIPPETS_STYLE_SPEC_HPP
+
+#include <climits>
+#include <concepts>
+#include <cstdint>
+#include <type_traits>
+
+namespace ants {
+class Style;
+
+/// Represents a `Style` rendering specification, including the text color, background color, and
+/// text styles (e.g., bold, italic, underline) when printed to the console.
+class StyleSpec {
+public:
+    /// Predefined colors that can be used for both text foreground and background. These color
+    /// names are based on the implementation of `rang`.
+    enum PredefinedColor : std::uint8_t {
+        Default,
+
+        Black,
+        Red,
+        Green,
+        Yellow,
+        Blue,
+        Magenta,
+        Cyan,
+        Gray,
+
+        BrightBlack,
+        BrightRed,
+        BrightGreen,
+        BrightYellow,
+        BrightBlue,
+        BrightMagenta,
+        BrightCyan,
+        BrightGray,
+    };
+
+    /// Predefined text styles. Multiple styles can be combined.
+    ///
+    /// Note: According to the `rang` documentation, `rang::style::blink` and `rang::style::rblink`
+    /// are not supported, hence there are no corresponding enumerators.
+    enum TextStyle : std::uint8_t {
+        Bold = 0x1,
+        Dim = 0x2,
+        Italic = 0x4,
+        Underline = 0x8,
+        Reversed = 0x10,
+        Conceal = 0x20,
+        Crossed = 0x40,
+    };
+
+    StyleSpec() = default;
+
+    /// This constructor allows for implicit conversion of a foreground color to `StyleSpec`.
+    constexpr StyleSpec(
+        PredefinedColor foreground_color,
+        PredefinedColor background_color = PredefinedColor::Default,
+        TextStyle text_styles = static_cast<TextStyle>(0)
+    ) :
+        text_styles_(static_cast<std::uint8_t>(text_styles)),
+        foreground_(foreground_color),
+        background_(background_color) { }
+
+    constexpr auto foreground_color() const -> PredefinedColor {
+        return foreground_;
+    }
+
+    constexpr void set_foreground_color(PredefinedColor color) {
+        foreground_ = color;
+    }
+
+    constexpr void reset_foreground_color() {
+        set_foreground_color(PredefinedColor::Default);
+    }
+
+    constexpr auto background_color() const -> PredefinedColor {
+        return background_;
+    }
+
+    constexpr void set_background_color(PredefinedColor color) {
+        background_ = color;
+    }
+
+    constexpr void reset_background_color() {
+        set_background_color(PredefinedColor::Default);
+    }
+
+    constexpr auto text_styles() const -> TextStyle {
+        return static_cast<TextStyle>(text_styles_);
+    }
+
+    constexpr auto has_text_style(TextStyle style) const -> bool {
+        return (text_styles_ & static_cast<std::uint8_t>(style)) != 0;
+    }
+
+    constexpr void add_text_style(TextStyle style) {
+        text_styles_ |= static_cast<std::uint8_t>(style);
+    }
+
+    constexpr void remove_text_style(TextStyle style) {
+        text_styles_ &= ~static_cast<std::uint8_t>(style);
+    }
+
+    constexpr void clear_text_styles() {
+        text_styles_ = 0;
+    }
+
+    friend constexpr auto operator+(StyleSpec lhs, StyleSpec::TextStyle rhs) -> StyleSpec {
+        lhs.add_text_style(rhs);
+        return lhs;
+    }
+
+    friend constexpr auto operator+(StyleSpec::TextStyle lhs, StyleSpec rhs) -> StyleSpec {
+        rhs.add_text_style(lhs);
+        return rhs;
+    }
+
+    friend constexpr auto operator+(PredefinedColor foreground_color, TextStyle rhs) -> StyleSpec {
+        return static_cast<StyleSpec>(foreground_color) + rhs;
+    }
+
+    friend constexpr auto operator+(TextStyle lhs, PredefinedColor foreground_color) -> StyleSpec {
+        return lhs + static_cast<StyleSpec>(foreground_color);
+    }
+
+    constexpr auto operator+=(TextStyle style) -> StyleSpec& {
+        add_text_style(style);
+        return *this;
+    }
+
+    friend constexpr auto operator-(StyleSpec lhs, StyleSpec::TextStyle rhs) -> StyleSpec {
+        lhs.remove_text_style(rhs);
+        return lhs;
+    }
+
+    constexpr auto operator-=(TextStyle style) -> StyleSpec& {
+        remove_text_style(style);
+        return *this;
+    }
+
+    friend constexpr auto operator==(StyleSpec const&, StyleSpec const&) -> bool = default;
+
+private:
+    /// Specified text styles (`TextStyle` and its combinations). We avoid using `std::bitset`
+    /// because its alignment requirements are too strict, which would make the size of `StyleSpec`
+    /// too large.
+    std::uint8_t text_styles_ = 0;
+    PredefinedColor foreground_ = PredefinedColor::Default;
+    PredefinedColor background_ = PredefinedColor::Default;
+};
+
+constexpr auto operator|(  //
+    StyleSpec::TextStyle lhs,
+    StyleSpec::TextStyle rhs
+) -> StyleSpec::TextStyle {
+    return static_cast<StyleSpec::TextStyle>(
+        static_cast<std::uint8_t>(lhs) | static_cast<std::uint8_t>(rhs)
+    );
+}
+
+constexpr auto operator&(  //
+    StyleSpec::TextStyle lhs,
+    StyleSpec::TextStyle rhs
+) -> StyleSpec::TextStyle {
+    return static_cast<StyleSpec::TextStyle>(
+        static_cast<std::uint8_t>(lhs) & static_cast<std::uint8_t>(rhs)
+    );
+}
+
+constexpr auto operator~(StyleSpec::TextStyle style) -> StyleSpec::TextStyle {
+    return static_cast<StyleSpec::TextStyle>(~static_cast<std::uint8_t>(style));
+}
+
+/// Checks if a callable type `StyleSheet` can be used as a style sheet for `HumanRenderer`.
+///
+/// The style sheet must be a callable object that accepts `Style` and `Level` as parameters. It
+/// determines how text with the specified `Style` should be rendered when the diagnostic level is
+/// `Level`. The rendering style is represented by the returned `StyleSpec`. Note that the return
+/// type of the style sheet must be convertible to `StyleSpec`, but it does not have to be exactly
+/// the same. This allows us to use `StyleSpec::PredefinedColor` as the return type, since it can be
+/// implicitly converted to `StyleSpec`.
+///
+/// TODO: Add an example demonstrating the use of a style sheet.
+template <class StyleSheet, class Level>
+concept style_sheet_for =
+    std::copy_constructible<StyleSheet> && std::regular_invocable<StyleSheet, Style const&, Level>
+    && std::convertible_to<std::invoke_result_t<StyleSheet, Style const&, Level>, StyleSpec>;
+
+/// Represents a style sheet that renders every `Style` in plain text format.
+struct PlainTextStyleSheet {
+    template <class Level>
+    constexpr auto operator()(Style const& /*unused*/, Level&& /*unused*/) const -> StyleSpec {
+        return {};
+    }
+};
+}  // namespace ants
+
+#endif  // ANNOTATE_SNIPPETS_STYLE_SPEC_HPP

--- a/include/annotate_snippets/style_spec.hpp
+++ b/include/annotate_snippets/style_spec.hpp
@@ -4,6 +4,8 @@
 #include <climits>
 #include <concepts>
 #include <cstdint>
+#include <ostream>
+#include <string_view>
 #include <type_traits>
 
 namespace ants {
@@ -62,6 +64,10 @@ public:
         text_styles_(static_cast<std::uint8_t>(text_styles)),
         foreground_(foreground_color),
         background_(background_color) { }
+
+    /// Outputs the string `content` to the output stream associated with `out`, rendered with the
+    /// current style.
+    void render_string(std::ostream& out, std::string_view content) const;
 
     constexpr auto foreground_color() const -> PredefinedColor {
         return foreground_;

--- a/src/style_spec.cpp
+++ b/src/style_spec.cpp
@@ -1,0 +1,66 @@
+#include "annotate_snippets/style_spec.hpp"
+
+#include <rang.hpp>
+
+#include <ostream>
+#include <string_view>
+
+namespace ants {
+void StyleSpec::render_string(std::ostream& out, std::string_view content) const {
+#define COLOR_SWITCH_BODY(ns) COLOR_CASES(ns) BRIGHT_COLOR_CASES(ns) DEFAULT_CASE(ns)
+
+#define COLOR_CASES(ns) COLOR_CASES_IMPL(ns, EMPTY)
+#define BRIGHT_COLOR_CASES(ns) COLOR_CASES_IMPL(ns##B, Bright)
+
+#define COLOR_CASES_IMPL(ns, prefix)                                                               \
+    COLOR_CASE(Black, black, ns, prefix)                                                           \
+    COLOR_CASE(Red, red, ns, prefix)                                                               \
+    COLOR_CASE(Green, green, ns, prefix)                                                           \
+    COLOR_CASE(Yellow, yellow, ns, prefix)                                                         \
+    COLOR_CASE(Blue, blue, ns, prefix)                                                             \
+    COLOR_CASE(Magenta, magenta, ns, prefix)                                                       \
+    COLOR_CASE(Cyan, cyan, ns, prefix)                                                             \
+    COLOR_CASE(Gray, gray, ns, prefix)
+
+#define EMPTY
+
+#define COLOR_CASE(from, to, ns, name_prefix)                                                      \
+    case StyleSpec::name_prefix##from:                                                             \
+        out << rang::ns::to;                                                                       \
+        break;
+
+#define DEFAULT_CASE(ns)                                                                           \
+    default:                                                                                       \
+        out << rang::ns::reset;                                                                    \
+        break;
+
+    // setup foreground and background colors
+    switch (foreground_) { COLOR_SWITCH_BODY(fg) }
+    switch (background_) { COLOR_SWITCH_BODY(bg) }
+
+    // clang-format off
+#define TEXT_STYLE_LIST                                                                            \
+    TEXT_STYLE_MAP(Bold, bold) TEXT_STYLE_MAP(Dim, dim) TEXT_STYLE_MAP(Italic, italic)             \
+    TEXT_STYLE_MAP(Underline, underline) TEXT_STYLE_MAP(Reversed, reversed)                         \
+    TEXT_STYLE_MAP(Conceal, conceal) TEXT_STYLE_MAP(Crossed, crossed)
+    // clang-format on
+
+    // setup text styles
+#define TEXT_STYLE_MAP(from, to)                                                                   \
+    if (has_text_style(StyleSpec::from))                                                           \
+        out << rang::style::to;
+    TEXT_STYLE_LIST
+#undef TEXT_STYLE_MAP
+
+    out << content << rang::fg::reset << rang::bg::reset << rang::style::reset;
+
+#undef TEXT_STYLE_LIST
+#undef DEFAULT_CASE
+#undef COLOR_CASE
+#undef EMPTY
+#undef COLOR_CASES_IMPL
+#undef BRIGHT_COLOR_CASES
+#undef COLOR_CASES
+#undef COLOR_SWITCH_BODY
+}
+}  // namespace ants

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(annotate_snippets_tests
     styled_string_view_test.cpp
     styled_string_test.cpp
     annotated_source_test.cpp
+    style_spec_test.cpp
 
     renderer/human_renderer_test/render_title_message.cpp
     renderer/human_renderer_test/render_singleline_annotation.cpp

--- a/test/style_spec_test.cpp
+++ b/test/style_spec_test.cpp
@@ -1,0 +1,145 @@
+#include "annotate_snippets/style_spec.hpp"
+
+#include "gtest/gtest.h"
+
+namespace {
+TEST(StyleSpecTest, Constructor) {
+    {
+        constexpr ants::StyleSpec spec(ants::StyleSpec::Red);
+        static_assert(spec.foreground_color() == ants::StyleSpec::Red);
+        static_assert(spec.background_color() == ants::StyleSpec::Default);
+        static_assert(spec.text_styles() == 0);
+    }
+
+    {
+        constexpr ants::StyleSpec spec = ants::StyleSpec::Red;
+        static_assert(spec.foreground_color() == ants::StyleSpec::Red);
+        static_assert(spec.background_color() == ants::StyleSpec::Default);
+        static_assert(spec.text_styles() == 0);
+    }
+
+    {
+        constexpr ants::StyleSpec spec(ants::StyleSpec::Red, ants::StyleSpec::Blue);
+        static_assert(spec.foreground_color() == ants::StyleSpec::Red);
+        static_assert(spec.background_color() == ants::StyleSpec::Blue);
+        static_assert(spec.text_styles() == 0);
+    }
+
+    {
+        constexpr ants::StyleSpec spec(  //
+            ants::StyleSpec::Red,
+            ants::StyleSpec::Blue,
+            ants::StyleSpec::Bold
+        );
+        static_assert(spec.foreground_color() == ants::StyleSpec::Red);
+        static_assert(spec.background_color() == ants::StyleSpec::Blue);
+        static_assert(spec.text_styles() == ants::StyleSpec::Bold);
+    }
+}
+
+TEST(StyleSpecTest, ForegroundColor) {
+    ants::StyleSpec spec;
+    EXPECT_EQ(spec.foreground_color(), ants::StyleSpec::Default);
+
+    spec.set_foreground_color(ants::StyleSpec::Blue);
+    EXPECT_EQ(spec.foreground_color(), ants::StyleSpec::Blue);
+
+    spec.set_foreground_color(ants::StyleSpec::Red);
+    EXPECT_EQ(spec.foreground_color(), ants::StyleSpec::Red);
+
+    spec.reset_foreground_color();
+    EXPECT_EQ(spec.foreground_color(), ants::StyleSpec::Default);
+}
+
+TEST(StyleSpecTest, BackgroundColor) {
+    ants::StyleSpec spec;
+    EXPECT_EQ(spec.background_color(), ants::StyleSpec::Default);
+
+    spec.set_background_color(ants::StyleSpec::Blue);
+    EXPECT_EQ(spec.background_color(), ants::StyleSpec::Blue);
+
+    spec.set_background_color(ants::StyleSpec::Red);
+    EXPECT_EQ(spec.background_color(), ants::StyleSpec::Red);
+
+    spec.reset_background_color();
+    EXPECT_EQ(spec.background_color(), ants::StyleSpec::Default);
+}
+
+TEST(StyleSpecTest, TextStyle) {
+    ants::StyleSpec spec;
+    EXPECT_EQ(spec.text_styles(), 0);
+
+    spec.add_text_style(ants::StyleSpec::Bold);
+    EXPECT_EQ(spec.text_styles(), ants::StyleSpec::Bold);
+    EXPECT_TRUE(spec.has_text_style(ants::StyleSpec::Bold));
+
+    spec.add_text_style(ants::StyleSpec::Italic);
+    EXPECT_TRUE(spec.has_text_style(ants::StyleSpec::Bold));
+    EXPECT_TRUE(spec.has_text_style(ants::StyleSpec::Italic));
+    EXPECT_EQ(spec.text_styles(), ants::StyleSpec::Bold | ants::StyleSpec::Italic);
+
+    spec.remove_text_style(ants::StyleSpec::Bold);
+    EXPECT_FALSE(spec.has_text_style(ants::StyleSpec::Bold));
+    EXPECT_TRUE(spec.has_text_style(ants::StyleSpec::Italic));
+    EXPECT_EQ(spec.text_styles(), ants::StyleSpec::Italic);
+
+    spec.add_text_style(ants::StyleSpec::Dim | ants::StyleSpec::Underline);
+    EXPECT_TRUE(spec.has_text_style(ants::StyleSpec::Dim));
+    EXPECT_TRUE(spec.has_text_style(ants::StyleSpec::Underline));
+    EXPECT_TRUE(spec.has_text_style(ants::StyleSpec::Italic));
+
+    spec.remove_text_style(ants::StyleSpec::Italic | ants::StyleSpec::Dim | ants::StyleSpec::Bold);
+    EXPECT_TRUE(spec.has_text_style(ants::StyleSpec::Underline));
+    EXPECT_FALSE(spec.has_text_style(ants::StyleSpec::Italic));
+    EXPECT_FALSE(spec.has_text_style(ants::StyleSpec::Dim));
+    EXPECT_FALSE(spec.has_text_style(ants::StyleSpec::Bold));
+
+    spec.clear_text_styles();
+    EXPECT_EQ(spec.text_styles(), 0);
+}
+
+TEST(StyleSpecTest, Operator) {
+    static_assert(
+        ants::StyleSpec(ants::StyleSpec::Red) + ants::StyleSpec::Bold
+        == ants::StyleSpec(ants::StyleSpec::Red, ants::StyleSpec::Default, ants::StyleSpec::Bold)
+    );
+    static_assert(
+        ants::StyleSpec(ants::StyleSpec::Red) + (ants::StyleSpec::Bold | ants::StyleSpec::Underline)
+        == ants::StyleSpec(
+            ants::StyleSpec::Red,
+            ants::StyleSpec::Default,
+            ants::StyleSpec::Bold | ants::StyleSpec::Underline
+        )
+    );
+    static_assert(
+        ants::StyleSpec::Bold + ants::StyleSpec(ants::StyleSpec::Red)
+        == ants::StyleSpec(ants::StyleSpec::Red, ants::StyleSpec::Default, ants::StyleSpec::Bold)
+    );
+
+    static_assert(
+        ants::StyleSpec::Red + ants::StyleSpec::Bold
+        == ants::StyleSpec(ants::StyleSpec::Red, ants::StyleSpec::Default, ants::StyleSpec::Bold)
+    );
+    static_assert(
+        ants::StyleSpec::Bold + ants::StyleSpec::Red == ants::StyleSpec::Red + ants::StyleSpec::Bold
+    );
+    static_assert(
+        ants::StyleSpec::Red + (ants::StyleSpec::Bold | ants::StyleSpec::Underline)
+        == ants::StyleSpec::Red + ants::StyleSpec::Bold + ants::StyleSpec::Underline
+    );
+
+    static_assert(
+        ants::StyleSpec(ants::StyleSpec::Red) - ants::StyleSpec::Bold
+        == ants::StyleSpec(ants::StyleSpec::Red)
+    );
+    static_assert(
+        ants::StyleSpec(ants::StyleSpec::Red) + ants::StyleSpec::Bold - ants::StyleSpec::Bold
+        == ants::StyleSpec(ants::StyleSpec::Red)
+    );
+    static_assert(
+        ants::StyleSpec(ants::StyleSpec::Red) + ants::StyleSpec::Bold + ants::StyleSpec::Underline
+            - ants::StyleSpec::Bold
+        == ants::StyleSpec(ants::StyleSpec::Red) + ants::StyleSpec::Underline
+    );
+}
+}  // namespace


### PR DESCRIPTION
This PR introduces colored output for diagnostic information rendering by implementing the `StyleSpec` class. The `StyleSpec` class allows specifying how strings with a certain `Style` should be displayed in the console. It can define the text color, background color, and text styles (bold, italic, underline, etc.). Users can declare how strings with different styles should be rendered by providing a stylesheet. We use `agauniyal/rang` as the backend for console color output.