### PR TITLE
Downgrade C++ Standard Requirement from C++23 to C++17

### DIFF
--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -18,9 +18,9 @@ jobs:
           sudo apt-get install -y wget lsb-release software-properties-common
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh 18
-          echo "CC=clang-18" >> $GITHUB_ENV
-          echo "CXX=clang++-18" >> $GITHUB_ENV
+          sudo ./llvm.sh 20
+          echo "CC=clang-20" >> $GITHUB_ENV
+          echo "CXX=clang++-20" >> $GITHUB_ENV
 
       - name: Create compilation database
         run: |

--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -18,9 +18,9 @@ jobs:
           sudo apt-get install -y wget lsb-release software-properties-common
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh 20
-          echo "CC=clang-20" >> $GITHUB_ENV
-          echo "CXX=clang++-20" >> $GITHUB_ENV
+          sudo ./llvm.sh 18
+          echo "CC=clang-18" >> $GITHUB_ENV
+          echo "CXX=clang++-18" >> $GITHUB_ENV
 
       - name: Create compilation database
         run: |

--- a/.github/workflows/gtest.yml
+++ b/.github/workflows/gtest.yml
@@ -112,9 +112,10 @@ jobs:
     strategy:
       matrix:
         build_type: [ Debug, Release ]
+        operating_system: [ windows-2019, windows-2022, windows-2025 ]
 
     name: Build and Test on Windows
-    runs-on: [ windows-2019, windows-2022, windows-2025 ]
+    runs-on: ${{matrix.operating_system}}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/gtest.yml
+++ b/.github/workflows/gtest.yml
@@ -28,11 +28,23 @@ jobs:
         if: startsWith(matrix.compiler, 'clang++')
         run: |
           sudo apt-get update
-          sudo apt-get install -y wget lsb-release software-properties-common
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          VERSION=$(echo ${{ matrix.compiler }} | cut -d'-' -f2) # Extracts the version number
-          sudo ./llvm.sh $VERSION
+          sudo apt-get install -y wget lsb-release software-properties-common gnupg
+
+          VERSION=$(echo ${{ matrix.compiler }} | cut -d'-' -f2)
+
+          if [ "$VERSION" -lt 9 ]; then
+            echo "Installing legacy Clang version $VERSION from llvm.org"
+            echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-$VERSION main" | sudo tee /etc/apt/sources.list.d/llvm.list
+            wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+            sudo apt-get update
+            sudo apt-get install -y clang-$VERSION lldb-$VERSION lld-$VERSION
+          else
+            echo "Installing modern Clang version $VERSION via llvm.sh"
+            wget https://apt.llvm.org/llvm.sh
+            chmod +x llvm.sh
+            sudo ./llvm.sh $VERSION
+          fi
+
           echo "CC=clang-$VERSION" >> $GITHUB_ENV
           echo "CXX=clang++-$VERSION" >> $GITHUB_ENV
 

--- a/.github/workflows/gtest.yml
+++ b/.github/workflows/gtest.yml
@@ -13,19 +13,10 @@ jobs:
         os: [ ubuntu-22.04 ]
         compiler: [ g++-7, g++-9, g++-11, g++-13, g++-15, clang++-5, clang++-10, clang++-15, clang++-20 ]
         build_type: [ Debug, Release ]
-        libcxx: [ false ]
         include:
           - compiler: clang++-5
-            build_type: Debug
-            libcxx: true
-          - compiler: clang++-5
-            build_type: Release
             libcxx: true
           - compiler: clang++-15
-            build_type: Debug
-            libcxx: true
-          - compiler: clang++-15
-            build_type: Release
             libcxx: true
 
     name: Build and Test on Ubuntu
@@ -42,10 +33,16 @@ jobs:
           chmod +x llvm.sh
           VERSION=$(echo ${{ matrix.compiler }} | cut -d'-' -f2) # Extracts the version number
           sudo ./llvm.sh $VERSION
+          echo "CC=clang-$VERSION" >> $GITHUB_ENV
+          echo "CXX=clang++-$VERSION" >> $GITHUB_ENV
 
+      - name: Install libc++
+        if: ${{ matrix.libcxx }}
+        run: |
           # Install libc++ if requested
           if [ "${{ matrix.libcxx }}" == "true" ]; then
             sudo apt-get install -y libc++-$VERSION-dev libc++abi-$VERSION-dev
+            echo "CXXFLAGS=-stdlib=libc++" >> $GITHUB_ENV
           fi
 
       - name: Install GCC
@@ -57,16 +54,9 @@ jobs:
 
       - name: Configure CMake
         run: |
-            CMAKE_FLAGS=""
-            if [ "${{ matrix.libcxx }}" == "true" ]; then
-              CMAKE_FLAGS="-DCMAKE_CXX_FLAGS=-stdlib=libc++"
-            fi
-
             cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" \
                   -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
-                  -DCMAKE_CXX_COMPILER=${{matrix.compiler}} \
-                  -DANNOTATE_SNIPPETS_ENABLE_TESTING=ON \
-                  $CMAKE_FLAGS
+                  -DANNOTATE_SNIPPETS_ENABLE_TESTING=ON
 
       - name: Build
         run: |

--- a/.github/workflows/gtest.yml
+++ b/.github/workflows/gtest.yml
@@ -62,6 +62,7 @@ jobs:
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
           sudo apt-get install -y ${{ matrix.compiler }}
+          echo "CXX=${{ matrix.compiler }}" >> $GITHUB_ENV
 
       - name: Configure CMake
         run: |

--- a/.github/workflows/gtest.yml
+++ b/.github/workflows/gtest.yml
@@ -11,14 +11,15 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-22.04 ]
-        compiler: [ g++-9, g++-11, g++-13, g++-15, clang++-11, clang++-15, clang++-20 ]
+        compiler: [ g++-9, g++-11, g++-13, clang++-11, clang++-15, clang++-20 ]
         build_type: [ Debug, Release ]
-        include:
-          - compiler: clang++-11
+        libcxx: [ false, true ]
+        exclude:
+          - compiler: g++-9
             libcxx: true
-          - compiler: clang++-15
+          - compiler: g++-11
             libcxx: true
-          - compiler: clang++-20
+          - compiler: g++-13
             libcxx: true
 
     name: Build and Test on Ubuntu

--- a/.github/workflows/gtest.yml
+++ b/.github/workflows/gtest.yml
@@ -11,10 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-22.04 ]
-        compiler: [
-          g++-7, g++-9, g++-11, g++-13, g++-15,
-          clang++-5, clang++-10, clang++-15, clang++-20
-        ]
+        compiler: [ g++-7, g++-9, g++-11, g++-13, g++-15, clang++-5, clang++-10, clang++-15, clang++-20 ]
         build_type: [ Debug, Release ]
         libcxx: [ false ]
         include:
@@ -112,10 +109,10 @@ jobs:
     strategy:
       matrix:
         build_type: [ Debug, Release ]
-        operating_system: [ windows-2019, windows-2022, windows-2025 ]
+        os: [ windows-2019, windows-2022, windows-2025 ]
 
     name: Build and Test on Windows
-    runs-on: ${{matrix.operating_system}}
+    runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/gtest.yml
+++ b/.github/workflows/gtest.yml
@@ -11,8 +11,25 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-22.04 ]
-        compiler: [ g++-11, g++-12, g++-13, clang++-16, clang++-17, clang++-18 ]
+        compiler: [
+          g++-7, g++-9, g++-11, g++-13, g++-15,
+          clang++-5, clang++-10, clang++-15, clang++-20
+        ]
         build_type: [ Debug, Release ]
+        libcxx: [ false ]
+        include:
+          - compiler: clang++-5
+            build_type: Debug
+            libcxx: true
+          - compiler: clang++-5
+            build_type: Release
+            libcxx: true
+          - compiler: clang++-15
+            build_type: Debug
+            libcxx: true
+          - compiler: clang++-15
+            build_type: Release
+            libcxx: true
 
     name: Build and Test on Ubuntu
     runs-on: ${{matrix.os}}
@@ -28,8 +45,11 @@ jobs:
           chmod +x llvm.sh
           VERSION=$(echo ${{ matrix.compiler }} | cut -d'-' -f2) # Extracts the version number
           sudo ./llvm.sh $VERSION
-          echo "CC=clang-$VERSION" >> $GITHUB_ENV
-          echo "CXX=clang++-$VERSION" >> $GITHUB_ENV
+
+          # Install libc++ if requested
+          if [ "${{ matrix.libcxx }}" == "true" ]; then
+            sudo apt-get install -y libc++-$VERSION-dev libc++abi-$VERSION-dev
+          fi
 
       - name: Install GCC
         if: startsWith(matrix.compiler, 'g++')
@@ -37,13 +57,19 @@ jobs:
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
           sudo apt-get install -y ${{ matrix.compiler }}
-          echo "CXX=${{ matrix.compiler }}" >> $GITHUB_ENV
 
       - name: Configure CMake
         run: |
+            CMAKE_FLAGS=""
+            if [ "${{ matrix.libcxx }}" == "true" ]; then
+              CMAKE_FLAGS="-DCMAKE_CXX_FLAGS=-stdlib=libc++"
+            fi
+
             cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" \
                   -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
-                  -DANNOTATE_SNIPPETS_ENABLE_TESTING=ON
+                  -DCMAKE_CXX_COMPILER=${{matrix.compiler}} \
+                  -DANNOTATE_SNIPPETS_ENABLE_TESTING=ON \
+                  $CMAKE_FLAGS
 
       - name: Build
         run: |
@@ -58,21 +84,13 @@ jobs:
   build-macos:
     strategy:
       matrix:
-        os: [ macos-14 ]
+        os: [ macos-13, macos-14, macos-15 ]
         build_type: [ Debug, Release ]
 
     name: Build and Test on MacOS
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v4
-
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          # FIXME: Use `latest` instead of `latest-stable` to use the latest beta version of Xcode,
-          # as Xcode 16 is a beta version on `macos-14`.
-          # TODO: Change this to a fixed version of Xcode when the GitHub Actions environment is
-          # updated.
-          xcode-version: latest
 
       - name: Configure CMake
         run: |
@@ -96,7 +114,7 @@ jobs:
         build_type: [ Debug, Release ]
 
     name: Build and Test on Windows
-    runs-on: windows-latest
+    runs-on: [ windows-2019, windows-2022, windows-2025 ]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/gtest.yml
+++ b/.github/workflows/gtest.yml
@@ -69,6 +69,7 @@ jobs:
         run: |
             cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" \
                   -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
+                  -DCMAKE_CXX_STANDARD=17 \
                   -DANNOTATE_SNIPPETS_ENABLE_TESTING=ON
 
       - name: Build
@@ -96,6 +97,7 @@ jobs:
         run: |
             cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" \
                   -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
+                  -DCMAKE_CXX_STANDARD=17 \
                   -DANNOTATE_SNIPPETS_ENABLE_TESTING=ON
 
       - name: Build
@@ -123,6 +125,7 @@ jobs:
         run: |
             cmake -S "${{github.workspace}}" -B "${{github.workspace}}/build" \
                   -DCMAKE_BUILD_TYPE=${{matrix.build_type}} \
+                  -DCMAKE_CXX_STANDARD=17 \
                   -DANNOTATE_SNIPPETS_ENABLE_TESTING=ON
 
       - name: Build

--- a/.github/workflows/gtest.yml
+++ b/.github/workflows/gtest.yml
@@ -11,12 +11,14 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-22.04 ]
-        compiler: [ g++-7, g++-9, g++-11, g++-13, g++-15, clang++-5, clang++-10, clang++-15, clang++-20 ]
+        compiler: [ g++-9, g++-11, g++-13, g++-15, clang++-11, clang++-15, clang++-20 ]
         build_type: [ Debug, Release ]
         include:
-          - compiler: clang++-5
+          - compiler: clang++-11
             libcxx: true
           - compiler: clang++-15
+            libcxx: true
+          - compiler: clang++-20
             libcxx: true
 
     name: Build and Test on Ubuntu
@@ -28,21 +30,17 @@ jobs:
         if: startsWith(matrix.compiler, 'clang++')
         run: |
           sudo apt-get update
-          sudo apt-get install -y wget lsb-release software-properties-common gnupg
+          sudo apt-get install -y wget lsb-release software-properties-common
+          VERSION=$(echo ${{ matrix.compiler }} | cut -d'-' -f2) # Extracts the version number
 
-          VERSION=$(echo ${{ matrix.compiler }} | cut -d'-' -f2)
-
-          if [ "$VERSION" -lt 9 ]; then
-            echo "Installing legacy Clang version $VERSION from llvm.org"
-            echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-$VERSION main" | sudo tee /etc/apt/sources.list.d/llvm.list
-            wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-            sudo apt-get update
-            sudo apt-get install -y clang-$VERSION lldb-$VERSION lld-$VERSION
-          else
-            echo "Installing modern Clang version $VERSION via llvm.sh"
+          if ! apt-cache show clang-$VERSION > /dev/null 2>&1; then
+            echo "clang-$VERSION not available via apt, using llvm.sh"
             wget https://apt.llvm.org/llvm.sh
             chmod +x llvm.sh
             sudo ./llvm.sh $VERSION
+          else
+            echo "Installing clang-$VERSION via apt"
+            sudo apt-get install -y clang-$VERSION
           fi
 
           echo "CC=clang-$VERSION" >> $GITHUB_ENV
@@ -53,6 +51,7 @@ jobs:
         run: |
           # Install libc++ if requested
           if [ "${{ matrix.libcxx }}" == "true" ]; then
+            VERSION=$(echo ${{ matrix.compiler }} | cut -d'-' -f2) # Extracts the version number
             sudo apt-get install -y libc++-$VERSION-dev libc++abi-$VERSION-dev
             echo "CXXFLAGS=-stdlib=libc++" >> $GITHUB_ENV
           fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,9 +31,6 @@ option(
 )
 option(INSTALL_ANNOTATE_SNIPPETS "Enable installation of the annotate-snippets project." ON)
 
-set(CMAKE_CXX_STANDARD 23)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 include(AddRang)
 
 add_library(annotate_snippets
@@ -56,6 +53,7 @@ target_compile_options(annotate_snippets
 )
 
 target_link_libraries(annotate_snippets PRIVATE rang::rang)
+target_compile_features(annotate_snippets PUBLIC cxx_std_17)
 
 add_library(ants::annotate_snippets ALIAS annotate_snippets)
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ target_link_libraries(your_target PRIVATE ants::annotate_snippets)
 ```
 
 > [!NOTE]
-> Currently `annotate-snippets` is developed using C++23, which has higher requirements for the compiler version. We are lowering the language standard used in the project to C++17.
+> To use `annotate-snippets`, your compiler should support at least C++17.
 
 ## Quick Start
 
@@ -64,9 +64,9 @@ enum class Level {
     SomethingIWant,
 };
 ```
-You can define your own `Level` enumeration arbitrarily. Then you need to define a function `display_string()` that converts `Level` to a string, and `annotate-snippets` will use this function to convert `Level` to the diagnostic level title printed on the screen:
+You can define your own `Level` enumeration arbitrarily. Then you need to define a function `title()` that converts `Level` to a string, and `annotate-snippets` will use this function to convert `Level` to the diagnostic level title printed on the screen:
 ```c++
-auto display_string(Level level) -> char const* {
+auto title(Level level) -> char const* {
     switch (level) {
     case Level::Fatal:
         return "fatal error";
@@ -114,6 +114,7 @@ source.add_annotation(
     "function body"
 );
 // Add a secondary annotation to `World`.
+//
 // By default, the underline of the primary annotation is "^^^", and the underline of the secondary
 // annotation is "---".
 source.add_secondary_annotation(45, 50, "secondary label");

--- a/include/annotate_snippets/annotated_source.hpp
+++ b/include/annotate_snippets/annotated_source.hpp
@@ -3,10 +3,9 @@
 
 #include "annotate_snippets/styled_string_view.hpp"
 
-#include <concepts>
 #include <cstddef>
+#include <iterator>
 #include <map>
-#include <ranges>
 #include <string_view>
 #include <utility>
 #include <vector>
@@ -20,7 +19,9 @@ struct SourceLocation {
     /// The (0-indexed) column number of the location.
     unsigned col;
 
-    auto operator==(SourceLocation const& other) const -> bool = default;
+    friend constexpr auto operator==(SourceLocation lhs, SourceLocation rhs) -> bool {
+        return lhs.line == rhs.line && lhs.col == rhs.col;
+    }
 };
 
 /// Represents a single annotation span in the source code, with an optional label. When rendering
@@ -106,17 +107,9 @@ public:
         line_offsets_[line] = offset;
     }
 
-    template <std::ranges::input_range Range>
-        requires std::convertible_to<
-            std::ranges::range_reference_t<Range>,
-            std::map<unsigned, std::size_t>::value_type>
-    void set_line_offsets(Range&& r) {
-#ifdef __cpp_lib_containers_ranges
-        line_offsets_.insert_range(std::forward<Range>(r));
-#else
-        auto&& cr = r | std::views::common;
-        line_offsets_.insert(std::ranges::begin(cr), std::ranges::end(cr));
-#endif
+    template <class Iter>
+    void set_line_offsets(Iter begin, Iter end) {
+        line_offsets_.insert(std::make_move_iterator(begin), std::make_move_iterator(end));
     }
 
     /// Returns the line and column number of the byte at offset `byte_offset` in the source code.
@@ -152,11 +145,13 @@ public:
         SourceLocation end,
         StyledStringView label
     ) {
-        primary_spans_.push_back(LabeledSpan {
-            .beg = beg,
-            .end = end,
-            .label = std::move(label),
-        });
+        primary_spans_.push_back(
+            LabeledSpan {
+                /*beg=*/beg,
+                /*end=*/end,
+                /*label=*/std::move(label),
+            }
+        );
     }
 
     auto with_primary_labeled_annotation(
@@ -291,11 +286,13 @@ public:
         SourceLocation end,
         StyledStringView label
     ) {
-        secondary_spans_.push_back(LabeledSpan {
-            .beg = beg,
-            .end = end,
-            .label = std::move(label),
-        });
+        secondary_spans_.push_back(
+            LabeledSpan {
+                /*beg=*/beg,
+                /*end=*/end,
+                /*label=*/std::move(label),
+            }
+        );
     }
 
     auto with_secondary_labeled_annotation(
@@ -562,16 +559,16 @@ private:
     /// is used to quickly find a line of source code when rendering diagnostic information.
     ///
     /// There are several ways to modify the cache:
-    ///     1. The user can explicitly specify the offset of the starting byte of a line by
-    ///     `set_line_offset()` and `set_line_offsets()`, because this information is usually known
-    ///     in other compilation stages, for example, the source code may have been scanned to
-    ///     obtain the offset of each line. Explicitly setting the cache will improve the
-    ///     performance of rendering diagnostic information, because the renderer does not need to
-    ///     find the starting position of a line separately.
-    ///     2. If there is no information about the first byte position of a line, when the code of
-    ///     this line needs to be accessed, the information will be calculated and cached. We try to
-    ///     iterate over as few bytes as possible to find the information we need, for example we
-    ///     might process a new line from an already calculated line.
+    /// 1. The user can explicitly specify the offset of the starting byte of a line by
+    ///    `set_line_offset()` and `set_line_offsets()`, because this information is usually known
+    ///    in other compilation stages, for example, the source code may have been scanned to obtain
+    ///    the offset of each line. Explicitly setting the cache will improve the performance of
+    ///    rendering diagnostic information, because the renderer does not need to find the starting
+    ///    position of a line separately.
+    /// 2. If there is no information about the first byte position of a line, when the code of this
+    ///    line needs to be accessed, the information will be calculated and cached. We try to
+    ///    iterate over as few bytes as possible to find the information we need, for example we
+    ///    might process a new line from an already calculated line.
     std::map<unsigned, std::size_t> line_offsets_;
     /// The (1-indexed) line number of the first line in the source code. The line numbers of
     /// subsequent lines will be calculated based on this, which allows us to provide a portion of

--- a/include/annotate_snippets/annotated_source.hpp
+++ b/include/annotate_snippets/annotated_source.hpp
@@ -145,13 +145,11 @@ public:
         SourceLocation end,
         StyledStringView label
     ) {
-        primary_spans_.push_back(
-            LabeledSpan {
-                /*beg=*/beg,
-                /*end=*/end,
-                /*label=*/std::move(label),
-            }
-        );
+        primary_spans_.push_back(LabeledSpan {
+            /*beg=*/beg,
+            /*end=*/end,
+            /*label=*/std::move(label),
+        });
     }
 
     auto with_primary_labeled_annotation(
@@ -286,13 +284,11 @@ public:
         SourceLocation end,
         StyledStringView label
     ) {
-        secondary_spans_.push_back(
-            LabeledSpan {
-                /*beg=*/beg,
-                /*end=*/end,
-                /*label=*/std::move(label),
-            }
-        );
+        secondary_spans_.push_back(LabeledSpan {
+            /*beg=*/beg,
+            /*end=*/end,
+            /*label=*/std::move(label),
+        });
     }
 
     auto with_secondary_labeled_annotation(

--- a/include/annotate_snippets/detail/diag/level.hpp
+++ b/include/annotate_snippets/detail/diag/level.hpp
@@ -43,7 +43,7 @@ struct LevelTitleImpl {
 /// screen.
 constexpr inline LevelTitleImpl level_title {};
 
-/// Checks whether type Ty can be used as the level type for diagnostic information.
+/// Checks whether type `Ty` can be used as the diagnostic level type for diagnostic information.
 template <class Ty>
 constexpr bool is_diagnostic_level = std::disjunction_v<has_member_title<Ty>, has_adl_title<Ty>>;
 }  // namespace ants::detail

--- a/include/annotate_snippets/detail/diag/level.hpp
+++ b/include/annotate_snippets/detail/diag/level.hpp
@@ -1,46 +1,51 @@
 #ifndef ANNOTATE_SNIPPETS_DETAIL_DIAG_LEVEL_HPP
 #define ANNOTATE_SNIPPETS_DETAIL_DIAG_LEVEL_HPP
 
-#include <concepts>
 #include <string_view>
+#include <type_traits>
 
 namespace ants::detail {
-/// Checks if LevelTy has a member display_string() function to convert it to a corresponding
-/// displayable string.
-template <class LevelTy>
-concept has_member_display_string = requires(LevelTy&& level) {
-    { level.display_string() } -> std::convertible_to<std::string_view>;
-};
+/// Checks if `LevelTy` has a member `title()` function to convert it to a corresponding displayable
+/// string.
+template <class LevelTy, class = void>
+struct has_member_title : std::false_type { };  // NOLINT(readability-identifier-naming)
 
-/// Checks whether the display_string() function can be found via ADL with an argument of type
-/// LevelTy, which is used to convert the level to its corresponding displayable string.
 template <class LevelTy>
-concept has_adl_display_string = !has_member_display_string<LevelTy> && requires(LevelTy&& level) {
-    { display_string(level) } -> std::convertible_to<std::string_view>;
-};
+struct has_member_title<LevelTy, std::void_t<decltype(std::declval<LevelTy const&>().title())>> :
+    std::is_convertible<decltype(std::declval<LevelTy const&>().title()), std::string_view> { };
 
-struct DisplayStringImpl {
-    template <has_member_display_string LevelTy>
-    constexpr auto operator()(LevelTy&& level) const -> std::string_view {
-        return static_cast<std::string_view>(level.display_string());
+/// Checks whether the `title()` function can be found via ADL with an argument of type `LevelTy`,
+/// which is used to convert the level to its corresponding displayable string.
+template <class LevelTy, class = void>
+struct has_adl_title : std::false_type { };  // NOLINT(readability-identifier-naming)
+
+template <class LevelTy>
+struct has_adl_title<LevelTy, std::void_t<decltype(title(std::declval<LevelTy const&>()))>> :
+    std::is_convertible<decltype(title(std::declval<LevelTy const&>())), std::string_view> { };
+
+struct LevelTitleImpl {
+    template <class LevelTy, std::enable_if_t<has_member_title<LevelTy>::value, int> = 0>
+    constexpr auto operator()(LevelTy const& level) const -> std::string_view {
+        return static_cast<std::string_view>(level.title());
     }
 
-    template <has_adl_display_string LevelTy>
-    constexpr auto operator()(LevelTy&& level) const -> std::string_view {
-        return static_cast<std::string_view>(display_string(level));
+    template <
+        class LevelTy,
+        std::enable_if_t<
+            std::conjunction_v<has_adl_title<LevelTy>, std::negation<has_member_title<LevelTy>>>,
+            int> = 0>
+    constexpr auto operator()(LevelTy const& level) const -> std::string_view {
+        return static_cast<std::string_view>(title(level));
     }
-
-    void operator()(auto&&) const = delete;
 };
 
 /// A customization point object used to convert the level object to a string displayable on the
 /// screen.
-constexpr inline DisplayStringImpl level_display_string {};
+constexpr inline LevelTitleImpl level_title {};
 
 /// Checks whether type Ty can be used as the level type for diagnostic information.
 template <class Ty>
-concept diagnostic_level =
-    std::regular<Ty> && requires(Ty&& level) { level_display_string(level); };
+constexpr bool is_diagnostic_level = std::disjunction_v<has_member_title<Ty>, has_adl_title<Ty>>;
 }  // namespace ants::detail
 
 #endif  // ANNOTATE_SNIPPETS_DETAIL_DIAG_LEVEL_HPP

--- a/include/annotate_snippets/detail/styled_string_impl.hpp
+++ b/include/annotate_snippets/detail/styled_string_impl.hpp
@@ -56,13 +56,11 @@ protected:
     std::vector<StyledPart> styled_parts_;
 
     // clang-format off
-    StyledStringImpl() :
-        styled_parts_ {
-            { /*start_index=*/0, /*style=*/ {} },
-            { /*start_index=*/0, /*style=*/ {} },
-        } { }
-
+    StyledStringImpl() : styled_parts_ {
+        { /*start_index=*/0, /*style=*/ {} }, { /*start_index=*/0, /*style=*/ {} }
+    } { }
     // clang-format on
+
     explicit StyledStringImpl(std::vector<StyledPart> parts) : styled_parts_(std::move(parts)) { }
 
     // clang-format off

--- a/include/annotate_snippets/detail/styled_string_impl.hpp
+++ b/include/annotate_snippets/detail/styled_string_impl.hpp
@@ -18,7 +18,19 @@ struct StyledStringViewPart {
     std::string_view content;
     Style style;
 
-    auto operator==(StyledStringViewPart const& other) const -> bool = default;
+    friend auto operator==(  //
+        StyledStringViewPart const& lhs,
+        StyledStringViewPart const& rhs
+    ) -> bool {
+        return lhs.content == rhs.content && lhs.style == rhs.style;
+    }
+
+    friend auto operator!=(  //
+        StyledStringViewPart const& lhs,
+        StyledStringViewPart const& rhs
+    ) -> bool {
+        return !(lhs == rhs);
+    }
 };
 
 namespace detail {
@@ -44,18 +56,20 @@ protected:
     std::vector<StyledPart> styled_parts_;
 
     // clang-format off
-    StyledStringImpl() : styled_parts_ {
-        { .start_index = 0, .style {} }, { .start_index = 0, .style {} }
-    } { }
-    // clang-format on
+    StyledStringImpl() :
+        styled_parts_ {
+            { /*start_index=*/0, /*style=*/ {} },
+            { /*start_index=*/0, /*style=*/ {} },
+        } { }
 
+    // clang-format on
     explicit StyledStringImpl(std::vector<StyledPart> parts) : styled_parts_(std::move(parts)) { }
 
     // clang-format off
     explicit StyledStringImpl(std::size_t content_size, Style content_style) : styled_parts_ { {
         // We need at least two `StyledPart` elements to specify the style of the whole string.
-        { .start_index = 0, .style = content_style },
-        { .start_index = content_size, .style {} },
+        { /*start_index=*/ 0, /*style=*/ content_style },
+        { /*start_index=*/ content_size, /*style=*/ {} },
     } } { }
     // clang-format on
 

--- a/include/annotate_snippets/detail/unicode_display_width.hpp
+++ b/include/annotate_snippets/detail/unicode_display_width.hpp
@@ -90,7 +90,7 @@ inline void for_each_codepoint(std::string_view s, F f) {
     }
     if (auto num_chars_left = s.data() + s.size() - p) {
         char buf[2 * block_size - 1] = {};
-        std::ranges::copy(p, p + num_chars_left, buf);
+        std::copy(p, p + num_chars_left, buf);
         const char* buf_ptr = buf;
         do {
             auto end = decode(buf_ptr, p);

--- a/include/annotate_snippets/renderer/human_renderer.hpp
+++ b/include/annotate_snippets/renderer/human_renderer.hpp
@@ -15,8 +15,8 @@
 #include <cstdint>
 #include <functional>
 #include <ostream>
-#include <ranges>
 #include <string_view>
+#include <type_traits>
 #include <vector>
 
 namespace ants {
@@ -155,7 +155,10 @@ public:
 
     /// Renders `diag` to the output stream associated with `out`. The rendering style is specified
     /// by `style_sheet`.
-    template <class Level, style_sheet_for<Level> StyleSheet = PlainTextStyleSheet>
+    template <
+        class Level,
+        class StyleSheet = PlainTextStyleSheet,
+        std::enable_if_t<is_style_sheet<StyleSheet, Level>, int> = 0>
     void render_diag(std::ostream& out, Diag<Level> diag, StyleSheet style_sheet = {}) const {
         unsigned const max_line_num_len = compute_max_line_num_len(diag);
 
@@ -186,10 +189,13 @@ public:
         // it is not associated with any source code (if `diag_entry.associated_source()` is empty,
         // then `std::ranges::any_of` returns `false`), then the current diagnostic entry does not
         // need to render annotations.
-        bool const has_annotation =
-            std::ranges::any_of(diag_entry.associated_sources(), [](AnnotatedSource const& source) {
+        bool const has_annotation = std::any_of(
+            diag_entry.associated_sources().begin(),
+            diag_entry.associated_sources().end(),
+            [](AnnotatedSource const& source) {
                 return !source.primary_spans().empty() || !source.secondary_spans().empty();
-            });
+            }
+        );
 
         // Indentation for the title message. Usually, this indentation is 0. When `short_message`
         // is `true`, since we need to render the file name and line/column numbers before the title
@@ -205,7 +211,7 @@ public:
 
         render_title_message(
             render_target,
-            detail::level_display_string(diag_entry.level()),
+            detail::level_title(diag_entry.level()),
             diag_entry.error_code(),
             diag_entry.diag_message(),
             max_line_num_len,
@@ -226,7 +232,11 @@ public:
 
     /// Renders a single `DiagEntry` to the output stream associated with `out`. The rendering style
     /// is specified by `style_sheet`.
-    template <class Level, class Derived, style_sheet_for<Level> StyleSheet>
+    template <
+        class Level,
+        class Derived,
+        class StyleSheet,
+        std::enable_if_t<is_style_sheet<StyleSheet, Level>, int> = 0>
     void render_diag_entry(
         std::ostream& out,
         detail::DiagEntryImpl<Level, Derived>& diag_entry,
@@ -272,35 +282,21 @@ private:
             return compute_max_line_num_len(source);
         };
 
-        unsigned const primary = [&] {
-            if (diag.primary_diag_entry().associated_sources().empty()) {
-                return 0u;
-            } else {
-                return std::ranges::max(
-                    diag.primary_diag_entry().associated_sources()
-                    | std::views::transform(source_trans)
-                );
-            }
-        }();
+        unsigned result = 0;
 
-        unsigned const secondary = [&] {
-            if (std::ranges::all_of(
-                    diag.secondary_diag_entries(),
-                    [](DiagEntry<Level> const& entry) { return entry.associated_sources().empty(); }
-                )) {
-                return 0u;
-            } else {
-                return std::ranges::max(
-                    diag.secondary_diag_entries()
-                    | std::views::transform([](DiagEntry<Level> const& entry) -> auto& {
-                          return entry.associated_sources();
-                      })
-                    | std::views::join | std::views::transform(source_trans)
-                );
-            }
-        }();
+        // Primary diag entry.
+        for (AnnotatedSource const& source : diag.primary_diag_entry().associated_sources()) {
+            result = std::max(result, compute_max_line_num_len(source));
+        }
 
-        return std::ranges::max(primary, secondary);
+        // Secondary diag entries.
+        for (DiagEntry<Level> const& entry : diag.secondary_diag_entries()) {
+            for (AnnotatedSource const& source : entry.associated_sources()) {
+                result = std::max(result, compute_max_line_num_len(source));
+            }
+        }
+
+        return result;
     }
 
     /// Renders the title message into `render_target`. For example:

--- a/include/annotate_snippets/renderer/human_renderer.hpp
+++ b/include/annotate_snippets/renderer/human_renderer.hpp
@@ -187,8 +187,8 @@ public:
     ) const {
         // If all associated source codes of the current diagnostic entry have no annotations, or if
         // it is not associated with any source code (if `diag_entry.associated_source()` is empty,
-        // then `std::ranges::any_of` returns `false`), then the current diagnostic entry does not
-        // need to render annotations.
+        // then `std::any_of` returns `false`), then the current diagnostic entry does not need to
+        // render annotations.
         bool const has_annotation = std::any_of(
             diag_entry.associated_sources().begin(),
             diag_entry.associated_sources().end(),

--- a/include/annotate_snippets/renderer/human_renderer.hpp
+++ b/include/annotate_snippets/renderer/human_renderer.hpp
@@ -275,7 +275,7 @@ private:
     template <class Level>
     auto compute_max_line_num_len(Diag<Level> const& diag) const -> unsigned {
         if (ui_testing) {
-            return anonymized_line_num.size();
+            return static_cast<unsigned>(anonymized_line_num.size());
         }
 
         auto const source_trans = [&](AnnotatedSource const& source) {

--- a/include/annotate_snippets/style.hpp
+++ b/include/annotate_snippets/style.hpp
@@ -110,7 +110,13 @@ public:
         return is(PredefinedStyle::Auto);
     }
 
-    auto operator==(Style const& other) const -> bool = default;
+    friend constexpr auto operator==(Style lhs, Style rhs) -> bool {
+        return lhs.style_ == rhs.style_;
+    }
+
+    friend constexpr auto operator!=(Style lhs, Style rhs) -> bool {
+        return !(lhs == rhs);
+    }
 
     /// Create a custom style based on a user-specified style number. The user can also achieve the
     /// same effect through the constructor, but the member function can indicate the user's

--- a/include/annotate_snippets/styled_string_view.hpp
+++ b/include/annotate_snippets/styled_string_view.hpp
@@ -4,9 +4,9 @@
 #include "annotate_snippets/detail/styled_string_impl.hpp"
 #include "annotate_snippets/style.hpp"
 
-#include <concepts>
 #include <cstddef>
 #include <string_view>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -30,8 +30,9 @@ public:
     /// Constructs a `StyledStringView` where its content is built from `args...`, as if constructed
     /// with `std::string_view(std::forward<Args>(args)...)`, and the style of the whole string will
     /// be inferred from the context in which the string is used (i.e. the `Style::Auto` style).
-    template <class... Args>
-        requires std::constructible_from<std::string_view, Args...>
+    template <
+        class... Args,
+        std::enable_if_t<std::is_constructible_v<std::string_view, Args...>, int> = 0>
     StyledStringView(Args&&... args) :
         StyledStringView(std::string_view(std::forward<Args>(args)...)) { }
 
@@ -79,8 +80,8 @@ public:
     void set_style(Style style) {
         // clang-format off
         std::vector<StyledPart> {
-            { .start_index = 0, .style = style },
-            { .start_index = content_.size(), .style {} },
+            { /*start_index=*/ 0, style },
+            { /*start_index=*/ content_.size(), /*style=*/ {} },
         }
             .swap(styled_parts_);
         // clang-format on

--- a/src/detail/styled_string_impl.cpp
+++ b/src/detail/styled_string_impl.cpp
@@ -17,7 +17,7 @@ void StyledStringImpl::set_style(Style style, std::size_t start_index, std::size
         return;
     }
 
-    // We assume that styled_parts_ is non-empty and styled_parts_.front().start_index is 0.
+    // We assume that `styled_parts_` is non-empty and `styled_parts_.front().start_index` is 0.
     auto const beg_iter = std::lower_bound(
         styled_parts_.begin(),
         styled_parts_.end(),
@@ -32,12 +32,12 @@ void StyledStringImpl::set_style(Style style, std::size_t start_index, std::size
     );
 
     // This iterator points to the last element to be removed. We must save the style of the
-    // element. Note that since the first element of styled_parts_ is 0, we can find that end_iter
-    // won't be styled_parts_.begin(), so that we can call prev() on it safely.
+    // element. Note that since the first element of `styled_parts_` is 0, we can find that
+    // `end_iter` won't be `styled_parts_.begin()`, so that we can call `prev()` on it safely.
     auto const last_iter = std::prev(end_iter);
     Style const end_style = last_iter->style;
 
-    // Replace the existing StyledParts in the range with updated StyledParts.
+    // Replace the existing `StyledPart`s in the range with updated `StyledPart`s.
     auto const insert_pos = styled_parts_.erase(beg_iter, end_iter);
     // clang-format off
     styled_parts_.insert(
@@ -54,8 +54,7 @@ auto StyledStringImpl::styled_line_parts(  //
     std::string_view content
 ) const -> std::vector<std::vector<StyledStringViewPart>> {
     std::vector<std::vector<StyledStringViewPart>> lines;
-    // Find the '\n' and split the content into multiple lines. We don't use std::ranges::split
-    // because we need to preserve the '\n' characters.
+    // Find the '\n' and split the content into multiple lines.
     for (std::size_t start = 0; start != content.size();) {
         std::size_t const pos = content.find('\n', start);
         if (pos == std::string_view::npos) {
@@ -77,9 +76,9 @@ auto StyledStringImpl::styled_line_parts(  //
         }
     }
 
-    // Merges parts with the same style within `styled_parts_`.
-    // It is considered easier and safer to merge parts with the same style here rather than
-    // enforcing that modifiers cannot insert parts with the same style.
+    // Merges parts with the same style within `styled_parts_`. It is considered easier and safer to
+    // merge parts with the same style here rather than enforcing that modifiers cannot insert parts
+    // with the same style.
     std::vector<StyledPart> merged_parts;
     merged_parts.reserve(styled_parts_.size());
     merged_parts.push_back(styled_parts_.front());
@@ -99,8 +98,8 @@ auto StyledStringImpl::styled_line_parts(  //
     // The index of the line we are currently processing.
     std::size_t cur_line_index = 0;
     for (std::size_t part_index = 0; part_index != merged_parts.size() - 1; ++part_index) {
-        // We must use two adjacent StyledPart objects to determine a substring, as stated in the
-        // documentation comment for the StyledPart class.
+        // We must use two adjacent `StyledPart` objects to determine a substring, as stated in the
+        // documentation comment for the `StyledPart` class.
         std::size_t part_beg = merged_parts[part_index].start_index;
         std::size_t const part_end = merged_parts[part_index + 1].start_index;
         Style const part_style = merged_parts[part_index].style;
@@ -116,7 +115,7 @@ auto StyledStringImpl::styled_line_parts(  //
             // Update the style of the unprocessed part.
             unprocessed_part.style = part_style;
 
-            // We must update part_beg here, because we may modify unprocessed_content later.
+            // We must update `part_beg` here, because we may modify `unprocessed_content` later.
             part_beg += unprocessed_content.size();
 
             // Remove '\n' and '\r\n'.
@@ -132,15 +131,15 @@ auto StyledStringImpl::styled_line_parts(  //
             // When a style ends at the position of a newline character, an extra empty string may
             // be generated, which is unexpected.
             //
-            // Fox example, we have a string "abc\n" of style Style::Auto and set the style of its
-            // substring "abc" as Style::Highlight. During processing, we will pack substring "abc"
-            // and its style Style::Highlight into a single StyledStringPart, and leave the string
-            // "\n" to be processed. When we process "\n", we will insert an empty string with
-            // Style::Auto into the result and generate unexpected result: { { "abc",
+            // Fox example, we have a string "abc\n" of style `Style::Auto` and set the style of its
+            // substring "abc" as `Style::Highlight`. During processing, we will pack substring
+            // "abc" and its style `Style::Highlight` into a single `StyledStringPart`, and leave
+            // the string "\n" to be processed. When we process "\n", we will insert an empty string
+            // with `Style::Auto` into the result and generate unexpected result: { { "abc",
             // Style::Highlight }, { "", Style::Auto } }. So we should remove the empty string here.
             //
             // Note that if a line is empty, we keep it. So we remove the unneeded elements at the
-            // end only if lines[cur_line_index].size() > 1 (which means the line is not empty).
+            // end only if `lines[cur_line_index].size() > 1` (which means the line is not empty).
             if (unprocessed_content.empty() && lines[cur_line_index].size() > 1) {
                 lines[cur_line_index].pop_back();
             }

--- a/src/detail/styled_string_impl.cpp
+++ b/src/detail/styled_string_impl.cpp
@@ -161,9 +161,11 @@ auto StyledStringImpl::styled_line_parts(  //
         std::string_view const rest_content =
             std::exchange(old_part.content, old_part.content.substr(0, part_end - part_beg))
                 .substr(part_end - part_beg);
+        // clang-format off
         lines[cur_line_index].push_back(
             StyledStringViewPart { /*content=*/rest_content, /*style=*/ {} }
         );
+        // clang-format on
     }
 
     return lines;

--- a/src/renderer/human_renderer.cpp
+++ b/src/renderer/human_renderer.cpp
@@ -14,7 +14,6 @@
 #include <iterator>
 #include <map>
 #include <queue>
-#include <ranges>
 #include <string>
 #include <string_view>
 #include <tuple>

--- a/src/renderer/human_renderer.cpp
+++ b/src/renderer/human_renderer.cpp
@@ -1299,12 +1299,15 @@ private:
     void handle_multiline_spans() {
         assign_multiline_depth();
 
-        // Compute the maximum depth. Note, if `multiline_annotations_` is not empty, what we're
-        // actually calculating is the maximum depth plus 1, as explained in the documentation
-        // comments for `depth_num_`.
+        // Compute the maximum depth.
         depth_num_ = 0;
         for (MultilineAnnotation const& annotation : multiline_annotations_) {
             depth_num_ = std::max(depth_num_, annotation.depth);
+        }
+        // Note that if `multiline_annotations_` is not empty, what we're actually calculating is
+        // the maximum depth plus 1, as explained in the documentation comments for `depth_num_`.
+        if (!multiline_annotations_.empty()) {
+            ++depth_num_;  // We need to add 1 to the maximum depth.
         }
 
         // Convert `MultilineAnnotation` into `Annotation`.

--- a/src/renderer/human_renderer.cpp
+++ b/src/renderer/human_renderer.cpp
@@ -1017,13 +1017,11 @@ private:
         // by the underlines of primary annotations and render them to the forefront. This ensures
         // we meet the second requirement.
         for (auto secondary_iter = annotations.begin(); secondary_iter != primary_annotations_begin;
-             ++secondary_iter)  //
-        {
+             ++secondary_iter) {
             auto const [secondary_beg, secondary_end] = secondary_iter->underline_display_range();
 
             for (auto primary_iter = primary_annotations_begin; primary_iter != annotations.end();
-                 ++primary_iter)  //
-            {
+                 ++primary_iter) {
                 auto const [primary_beg, primary_end] = primary_iter->underline_display_range();
 
                 // If the primary annotation completely covers the underline of the secondary
@@ -1441,8 +1439,8 @@ private:
 
             /// Determines whether the intervals represented by two `Vertex` overlap.
             auto overlap(Vertex const& other) const -> bool {
-                // We assume that the `annotation_range` in both vertices is non-empty, and that all
-                // elements in an `annotation_range` of a `Vertex` have the same line range.
+                // We assume that `associated_annotations` in both vertices is non-empty, and that
+                // all elements in `associated_annotations` of a `Vertex` have the same line range.
                 unsigned const self_line_beg = associated_annotations.first->beg.line;
                 unsigned const self_line_end = associated_annotations.first->end.line;
                 unsigned const other_line_beg = other.associated_annotations.first->beg.line;
@@ -1481,8 +1479,7 @@ private:
         // pair of overlapping intervals.
         for (auto cur_iter = interval_graph.begin(); cur_iter != interval_graph.end(); ++cur_iter) {
             for (auto neighbor_iter = std::next(cur_iter); neighbor_iter != interval_graph.end();
-                 ++neighbor_iter)  //
-            {
+                 ++neighbor_iter) {
                 if (cur_iter->overlap(*neighbor_iter)) {
                     cur_iter->neighbors.push_back(&*neighbor_iter);
                     neighbor_iter->neighbors.push_back(&*cur_iter);
@@ -1515,8 +1512,7 @@ private:
         for (Vertex const& vertex : interval_graph) {
             for (auto iter = vertex.associated_annotations.first;
                  iter != vertex.associated_annotations.second;
-                 ++iter)  //
-            {
+                 ++iter) {
                 // Since `vertex.depth` starts from 1, we need to subtract 1 additionally.
                 iter->depth = vertex.depth - 1;
             }
@@ -1619,8 +1615,7 @@ private:
                     [](Annotation const& annotation) {
                         return annotation.type != Annotation::MultilineBody;
                     }
-                ))  //
-            {
+                )) {
                 continue;
             }
 

--- a/test/annotated_source_test.cpp
+++ b/test/annotated_source_test.cpp
@@ -24,7 +24,7 @@ TEST(AnnotatedSourceTest, LineOffset) {
     {                                                                                              \
         TEST_CASE_IMPL(__VA_ARGS__)                                                                \
         std::decay_t<decltype(as.line_offsets_cache())> expected_cache;                            \
-        for (std::size_t i = 0; i != line_starts.size(); ++i) {                                    \
+        for (unsigned i = 0; i != static_cast<unsigned>(line_starts.size()); ++i) {                \
             expected_cache.emplace(i, line_starts[i]);                                             \
         }                                                                                          \
         EXPECT_EQ(expected_cache, as.line_offsets_cache());                                        \

--- a/test/annotated_source_test.cpp
+++ b/test/annotated_source_test.cpp
@@ -18,13 +18,12 @@ TEST(AnnotatedSourceTest, LineOffset) {
         }                                                                                          \
     }
 
-#define TEST_CASE(...)                                                                             \
-    { TEST_CASE_IMPL(__VA_ARGS__) }
+#define TEST_CASE(...) { TEST_CASE_IMPL(__VA_ARGS__) }
 
 #define TEST_CASE_CHECK_CACHE(...)                                                                 \
     {                                                                                              \
         TEST_CASE_IMPL(__VA_ARGS__)                                                                \
-        std::remove_cvref_t<decltype(as.line_offsets_cache())> expected_cache;                     \
+        std::decay_t<decltype(as.line_offsets_cache())> expected_cache;                            \
         for (std::size_t i = 0; i != line_starts.size(); ++i) {                                    \
             expected_cache.emplace(i, line_starts[i]);                                             \
         }                                                                                          \

--- a/test/annotated_source_test.cpp
+++ b/test/annotated_source_test.cpp
@@ -2,7 +2,6 @@
 
 #include "gtest/gtest.h"
 
-#include <cstddef>
 #include <type_traits>
 #include <vector>
 

--- a/test/renderer/human_renderer_test/level_for_test.hpp
+++ b/test/renderer/human_renderer_test/level_for_test.hpp
@@ -9,7 +9,7 @@ enum class Level {
     Help,
 };
 
-inline auto display_string(Level level) -> char const* {
+inline auto title(Level level) -> char const* {
     switch (level) {
     case Level::Fatal:
         return "fatal error";

--- a/test/renderer/human_renderer_test/render_singleline_annotation.cpp
+++ b/test/renderer/human_renderer_test/render_singleline_annotation.cpp
@@ -274,7 +274,8 @@ TEST(HumanRendererSinglelineAnnotationTest, LabelPosition) {
     std::cout << result << '\n';
 })";
 
-    ants::HumanRenderer renderer { .label_position = ants::HumanRenderer::Right };
+    ants::HumanRenderer renderer;
+    renderer.label_position = ants::HumanRenderer::Right;
 
     EXPECT_EQ(
         renderer

--- a/test/renderer/human_renderer_test/render_title_message.cpp
+++ b/test/renderer/human_renderer_test/render_title_message.cpp
@@ -135,7 +135,8 @@ TEST(HumanRendererTitleMessageTest, MultipleDiagEntries) {
 }
 
 TEST(HumanRendererTitleMessageTest, ShortMessage) {
-    ants::HumanRenderer const render { .short_message = true };
+    ants::HumanRenderer render;
+    render.short_message = true;
 
     EXPECT_EQ(
         render.render_diag(ants::Diag(Level::Error, ants::StyledStringView::inferred("message")))

--- a/test/styled_string_test.cpp
+++ b/test/styled_string_test.cpp
@@ -14,13 +14,13 @@ TEST(StyledStringTest, AppendContent) {
         auto str = ants::StyledString::inferred("Hello");
         EXPECT_EQ(
             str.styled_line_parts(),
-            (LineParts { { { .content = "Hello", .style = ants::Style::Auto } } })
+            (LineParts { { { /*content=*/"Hello", /*style=*/ants::Style::Auto } } })
         );
         str.append("World", ants::Style::Auto);
         EXPECT_EQ(str.content(), "HelloWorld");
         EXPECT_EQ(
             str.styled_line_parts(),
-            (LineParts { { { .content = "HelloWorld", .style = ants::Style::Auto } } })
+            (LineParts { { { /*content=*/"HelloWorld", /*style=*/ants::Style::Auto } } })
         );
         str.append(".", ants::Style::Default);
         EXPECT_EQ(str.content(), "HelloWorld.");
@@ -28,8 +28,8 @@ TEST(StyledStringTest, AppendContent) {
         EXPECT_EQ(
             str.styled_line_parts(),
             (LineParts { {
-                { .content = "HelloWorld", .style = ants::Style::Auto },
-                { .content = ".", .style = ants::Style::Default },
+                { /*content=*/"HelloWorld", /*style=*/ants::Style::Auto },
+                { /*content=*/".", /*style=*/ants::Style::Default },
             } })
         );
         // clang-format on
@@ -41,7 +41,7 @@ TEST(StyledStringTest, AppendContent) {
         EXPECT_EQ(str.content(), "Hello");
         EXPECT_EQ(
             str.styled_line_parts(),
-            (LineParts { { { .content = "Hello", .style = ants::Style::Auto } } })
+            (LineParts { { { /*content=*/"Hello", /*style=*/ants::Style::Auto } } })
         );
     }
 
@@ -65,7 +65,7 @@ TEST(StyledStringTest, AppendContent) {
         EXPECT_EQ(str.content(), "Hello");
         EXPECT_EQ(
             str.styled_line_parts(),
-            (LineParts { { { .content = "Hello", .style = ants::Style::Addition } } })
+            (LineParts { { { /*content=*/"Hello", /*style=*/ants::Style::Addition } } })
         );
     }
 
@@ -77,9 +77,9 @@ TEST(StyledStringTest, AppendContent) {
         EXPECT_EQ(
             str.styled_line_parts(),
             (LineParts { {
-                { .content = "He", .style = ants::Style::Auto },
-                { .content = "llo", .style = ants::Style::Default },
-                { .content = "World", .style = ants::Style::Auto },
+                { /*content=*/"He", /*style=*/ants::Style::Auto },
+                { /*content=*/"llo", /*style=*/ants::Style::Default },
+                { /*content=*/"World", /*style=*/ants::Style::Auto },
             } })
         );
         // clang-format on
@@ -93,8 +93,8 @@ TEST(StyledStringTest, AppendContent) {
         EXPECT_EQ(
             str.styled_line_parts(),
             (LineParts { {
-                { .content = "He", .style = ants::Style::Auto },
-                { .content = "lloWorld", .style = ants::Style::Default },
+                { /*content=*/"He", /*style=*/ants::Style::Auto },
+                { /*content=*/"lloWorld", /*style=*/ants::Style::Default },
             } })
         );
         // clang-format on
@@ -108,8 +108,8 @@ TEST(StyledStringTest, AppendContent) {
         EXPECT_EQ(
             str.styled_line_parts(),
             (LineParts { {
-                { .content = "Hello", .style = ants::Style::Default },
-                { .content = "World", .style = ants::Style::Highlight },
+                { /*content=*/"Hello", /*style=*/ants::Style::Default },
+                { /*content=*/"World", /*style=*/ants::Style::Highlight },
             } })
         );
         // clang-format on
@@ -121,7 +121,7 @@ TEST(StyledStringTest, AppendContent) {
         EXPECT_EQ(str.content(), "HelloWorld");
         EXPECT_EQ(
             str.styled_line_parts(),
-            (LineParts { { { .content = "HelloWorld", .style = ants::Style::Default } } })
+            (LineParts { { { /*content=*/"HelloWorld", /*style=*/ants::Style::Default } } })
         );
     }
 
@@ -133,8 +133,8 @@ TEST(StyledStringTest, AppendContent) {
         EXPECT_EQ(
             str.styled_line_parts(),
             (LineParts { {
-                { .content = "Hello", .style = ants::Style::Auto },
-                { .content = "World", .style = ants::Style::Highlight },
+                { /*content=*/"Hello", /*style=*/ants::Style::Auto },
+                { /*content=*/"World", /*style=*/ants::Style::Highlight },
             } })
         );
         // clang-format on
@@ -149,9 +149,9 @@ TEST(StyledStringTest, AppendContent) {
         EXPECT_EQ(
             str.styled_line_parts(),
             (LineParts { {
-                { .content = "Hel", .style = ants::Style::Auto },
-                { .content = "loW", .style = ants::Style::Default },
-                { .content = "orld", .style = ants::Style::Highlight },
+                { /*content=*/"Hel", /*style=*/ants::Style::Auto },
+                { /*content=*/"loW", /*style=*/ants::Style::Default },
+                { /*content=*/"orld", /*style=*/ants::Style::Highlight },
             } })
         );
         // clang-format on
@@ -168,8 +168,8 @@ TEST(StyledStringTest, AppendParts) {
         EXPECT_EQ(
             str.styled_line_parts(),
             (LineParts { {
-                { .content = "Hello", .style = ants::Style::Auto },
-                { .content = "World", .style = ants::Style::Addition },
+                { /*content=*/"Hello", /*style=*/ants::Style::Auto },
+                { /*content=*/"World", /*style=*/ants::Style::Addition },
             } })
         );
         // clang-format on
@@ -182,7 +182,7 @@ TEST(StyledStringTest, AppendParts) {
         EXPECT_EQ(str.content(), "HelloWorld");
         EXPECT_EQ(
             str.styled_line_parts(),
-            (LineParts { { { .content = "HelloWorld", .style = ants::Style::Auto } } })
+            (LineParts { { { /*content=*/"HelloWorld", /*style=*/ants::Style::Auto } } })
         );
     }
 
@@ -196,8 +196,8 @@ TEST(StyledStringTest, AppendParts) {
         EXPECT_EQ(
             str.styled_line_parts(),
             (LineParts { {
-                { .content = "HelloWor", .style = ants::Style::Auto },
-                { .content = "ld", .style = ants::Style::Default },
+                { /*content=*/"HelloWor", /*style=*/ants::Style::Auto },
+                { /*content=*/"ld", /*style=*/ants::Style::Default },
             } })
         );
         // clang-format on
@@ -205,22 +205,23 @@ TEST(StyledStringTest, AppendParts) {
 
     {
         auto str = ants::StyledString::inferred("Hello");
-        auto const append = ants::StyledString::inferred("World")
-                                .with_style(ants::Style::custom(1), 0)
-                                .with_style(ants::Style::custom(2), 1)
-                                .with_style(ants::Style::custom(3), 3)
-                                .with_style(ants::Style::custom(4), 4);
+        auto const append =  //
+            ants::StyledString::inferred("World")
+                .with_style(ants::Style::custom(1), 0)
+                .with_style(ants::Style::custom(2), 1)
+                .with_style(ants::Style::custom(3), 3)
+                .with_style(ants::Style::custom(4), 4);
         str.append(append.styled_line_parts().front());
         EXPECT_EQ(str.content(), "HelloWorld");
         // clang-format off
         EXPECT_EQ(
             str.styled_line_parts(),
             (LineParts { {
-                { .content = "Hello", .style = ants::Style::Auto },
-                { .content = "W", .style = ants::Style::custom(1) },
-                { .content = "or", .style = ants::Style::custom(2) },
-                { .content = "l", .style = ants::Style::custom(3) },
-                { .content = "d", .style = ants::Style::custom(4) },
+                { /*content=*/"Hello", /*style=*/ants::Style::Auto },
+                { /*content=*/"W", /*style=*/ants::Style::custom(1) },
+                { /*content=*/"or", /*style=*/ants::Style::custom(2) },
+                { /*content=*/"l", /*style=*/ants::Style::custom(3) },
+                { /*content=*/"d", /*style=*/ants::Style::custom(4) },
             } })
         );
         // clang-format on
@@ -228,11 +229,12 @@ TEST(StyledStringTest, AppendParts) {
 
     {
         auto str = ants::StyledString::inferred("");
-        auto const append = ants::StyledString::inferred("Hello")
-                                .with_style(ants::Style::custom(1), 0)
-                                .with_style(ants::Style::custom(2), 1)
-                                .with_style(ants::Style::custom(3), 3)
-                                .with_style(ants::Style::custom(4), 4);
+        auto const append =  //
+            ants::StyledString::inferred("Hello")
+                .with_style(ants::Style::custom(1), 0)
+                .with_style(ants::Style::custom(2), 1)
+                .with_style(ants::Style::custom(3), 3)
+                .with_style(ants::Style::custom(4), 4);
         str.append(append.styled_line_parts().front());
         EXPECT_EQ(str.content(), "Hello");
         EXPECT_EQ(str.styled_line_parts(), append.styled_line_parts());
@@ -248,9 +250,9 @@ TEST(StyledStringTest, AppendParts) {
         EXPECT_EQ(
             str.styled_line_parts(),
             (LineParts { {
-                { .content = "Hello", .style = ants::Style::Auto },
-                { .content = "Wor", .style = ants::Style::Highlight },
-                { .content = "ld", .style = ants::Style::Default },
+                { /*content=*/"Hello", /*style=*/ants::Style::Auto },
+                { /*content=*/"Wor", /*style=*/ants::Style::Highlight },
+                { /*content=*/"ld", /*style=*/ants::Style::Default },
             } })
         );
         // clang-format on
@@ -266,8 +268,8 @@ TEST(StyledStringTest, AppendParts) {
         EXPECT_EQ(
             str.styled_line_parts(),
             (LineParts { {
-                { .content = "HelloWor", .style = ants::Style::Default },
-                { .content = "ld", .style = ants::Style::Highlight },
+                { /*content=*/"HelloWor", /*style=*/ants::Style::Default },
+                { /*content=*/"ld", /*style=*/ants::Style::Highlight },
             } })
         );
         // clang-format on
@@ -281,7 +283,7 @@ TEST(StyledStringTest, AppendNewline) {
         EXPECT_EQ(str.content(), "Hello\n");
         EXPECT_EQ(
             str.styled_line_parts(),
-            (LineParts { { { .content = "Hello", .style = ants::Style::Auto } } })
+            (LineParts { { { /*content=*/"Hello", /*style=*/ants::Style::Auto } } })
         );
 
         str.append_newline();
@@ -289,10 +291,10 @@ TEST(StyledStringTest, AppendNewline) {
         // clang-format off
         EXPECT_EQ(
             str.styled_line_parts(),
-            (LineParts { {
-                { { .content = "Hello", .style = ants::Style::Auto } },
-                { { .content = "", .style = ants::Style::Auto } },
-            } })
+            (LineParts {
+                { { /*content=*/"Hello", /*style=*/ants::Style::Auto } },
+                { { /*content=*/"", /*style=*/ants::Style::Auto } },
+            })
         );
         // clang-format on
 
@@ -301,11 +303,11 @@ TEST(StyledStringTest, AppendNewline) {
         // clang-format off
         EXPECT_EQ(
             str.styled_line_parts(),
-            (LineParts { {
-                { { .content = "Hello", .style = ants::Style::Auto } },
-                { { .content = "", .style = ants::Style::Auto } },
-                { { .content = "World", .style = ants::Style::Default } },
-            } })
+            (LineParts {
+                { { /*content=*/"Hello", /*style=*/ants::Style::Auto } },
+                { { /*content=*/"", /*style=*/ants::Style::Auto } },
+                { { /*content=*/"World", /*style=*/ants::Style::Default } },
+            })
         );
         // clang-format on
     }
@@ -316,7 +318,7 @@ TEST(StyledStringTest, AppendNewline) {
         EXPECT_EQ(str.content(), "\n");
         EXPECT_EQ(
             str.styled_line_parts(),
-            (LineParts { { { .content = "", .style = ants::Style::Auto } } })
+            (LineParts { { { /*content=*/"", /*style=*/ants::Style::Auto } } })
         );
 
         str.append("Hello", ants::Style::Default);
@@ -324,10 +326,10 @@ TEST(StyledStringTest, AppendNewline) {
         // clang-format off
         EXPECT_EQ(
             str.styled_line_parts(),
-            (LineParts { {
-                { { .content = "", .style = ants::Style::Auto } },
-                { { .content = "Hello", .style = ants::Style::Default } },
-            } })
+            (LineParts {
+                { { /*content=*/"", /*style=*/ants::Style::Auto } },
+                { { /*content=*/"Hello", /*style=*/ants::Style::Default } },
+            })
         );
         // clang-format on
 
@@ -336,11 +338,11 @@ TEST(StyledStringTest, AppendNewline) {
         // clang-format off
         EXPECT_EQ(
             str.styled_line_parts(),
-            (LineParts { {
-                { { .content = "", .style = ants::Style::Auto } },
-                { { .content = "Hello", .style = ants::Style::Default } },
-                { { .content = "World", .style = ants::Style::Highlight } },
-            } })
+            (LineParts {
+                { { /*content=*/"", /*style=*/ants::Style::Auto } },
+                { { /*content=*/"Hello", /*style=*/ants::Style::Default } },
+                { { /*content=*/"World", /*style=*/ants::Style::Highlight } },
+            })
         );
         // clang-format on
     }
@@ -357,14 +359,14 @@ TEST(StyledStringTest, AppendSpace) {
         EXPECT_EQ(str.content(), "   ");
         EXPECT_EQ(
             str.styled_line_parts(),
-            (LineParts { { { .content = "   ", .style = ants::Style::Default } } })
+            (LineParts { { { /*content=*/"   ", /*style=*/ants::Style::Default } } })
         );
 
         str.append_spaces(2);
         EXPECT_EQ(str.content(), "     ");
         EXPECT_EQ(
             str.styled_line_parts(),
-            (LineParts { { { .content = "     ", .style = ants::Style::Default } } })
+            (LineParts { { { /*content=*/"     ", /*style=*/ants::Style::Default } } })
         );
 
         str.append("Hello", ants::Style::Auto);
@@ -374,9 +376,9 @@ TEST(StyledStringTest, AppendSpace) {
         EXPECT_EQ(
             str.styled_line_parts(),
             (LineParts { {
-                { .content = "     ", .style = ants::Style::Default },
-                { .content = "Hello", .style = ants::Style::Auto },
-                { .content = "   ", .style = ants::Style::Default },
+                { /*content=*/"     ", /*style=*/ants::Style::Default },
+                { /*content=*/"Hello", /*style=*/ants::Style::Auto },
+                { /*content=*/"   ", /*style=*/ants::Style::Default },
             } })
         );
         // clang-format on
@@ -390,8 +392,8 @@ TEST(StyledStringTest, AppendSpace) {
         EXPECT_EQ(
             str.styled_line_parts(),
             (LineParts { {
-                { .content = "Hello", .style = ants::Style::Auto },
-                { .content = " ", .style = ants::Style::Default },
+                { /*content=*/"Hello", /*style=*/ants::Style::Auto },
+                { /*content=*/" ", /*style=*/ants::Style::Default },
             } })
         );
         // clang-format on
@@ -402,8 +404,8 @@ TEST(StyledStringTest, AppendSpace) {
         EXPECT_EQ(
             str.styled_line_parts(),
             (LineParts { {
-                { .content = "Hello", .style = ants::Style::Auto },
-                { .content = " World", .style = ants::Style::Default },
+                { /*content=*/"Hello", /*style=*/ants::Style::Auto },
+                { /*content=*/" World", /*style=*/ants::Style::Default },
             } })
         );
         // clang-format on
@@ -419,8 +421,8 @@ TEST(StyledStringTest, SetStyledContent) {
         EXPECT_EQ(
             str.styled_line_parts(),
             (LineParts { {
-                { .content = "     ", .style = ants::Style::Default },
-                { .content = "Hello", .style = ants::Style::Auto },
+                { /*content=*/"     ", /*style=*/ants::Style::Default },
+                { /*content=*/"Hello", /*style=*/ants::Style::Auto },
             } })
         );
         // clang-format on
@@ -431,9 +433,9 @@ TEST(StyledStringTest, SetStyledContent) {
         EXPECT_EQ(
             str.styled_line_parts(),
             (LineParts { {
-                { .content = "     ", .style = ants::Style::Default },
-                { .content = "He", .style = ants::Style::Auto },
-                { .content = "World", .style = ants::Style::Highlight },
+                { /*content=*/"     ", /*style=*/ants::Style::Default },
+                { /*content=*/"He", /*style=*/ants::Style::Auto },
+                { /*content=*/"World", /*style=*/ants::Style::Highlight },
             } })
         );
         // clang-format on
@@ -444,11 +446,11 @@ TEST(StyledStringTest, SetStyledContent) {
         EXPECT_EQ(
             str.styled_line_parts(),
             (LineParts { {
-                { .content = "     ", .style = ants::Style::Default },
-                { .content = "He", .style = ants::Style::Auto },
-                { .content = "World", .style = ants::Style::Highlight },
-                { .content = "   ", .style = ants::Style::Default },
-                { .content = "C++", .style = ants::Style::custom(2) },
+                { /*content=*/"     ", /*style=*/ants::Style::Default },
+                { /*content=*/"He", /*style=*/ants::Style::Auto },
+                { /*content=*/"World", /*style=*/ants::Style::Highlight },
+                { /*content=*/"   ", /*style=*/ants::Style::Default },
+                { /*content=*/"C++", /*style=*/ants::Style::custom(2) },
             } })
         );
         // clang-format on
@@ -459,10 +461,10 @@ TEST(StyledStringTest, SetStyledContent) {
         EXPECT_EQ(
             str.styled_line_parts(),
             (LineParts { {
-                { .content = "   ", .style = ants::Style::Default },
-                { .content = "Helloorld", .style = ants::Style::Highlight },
-                { .content = "   ", .style = ants::Style::Default },
-                { .content = "C++", .style = ants::Style::custom(2) },
+                { /*content=*/"   ", /*style=*/ants::Style::Default },
+                { /*content=*/"Helloorld", /*style=*/ants::Style::Highlight },
+                { /*content=*/"   ", /*style=*/ants::Style::Default },
+                { /*content=*/"C++", /*style=*/ants::Style::custom(2) },
             } })
         );
         // clang-format on
@@ -473,10 +475,10 @@ TEST(StyledStringTest, SetStyledContent) {
         EXPECT_EQ(
             str.styled_line_parts(),
             (LineParts { {
-                { .content = "   ", .style = ants::Style::Default },
-                { .content = "Helloorld", .style = ants::Style::Highlight },
-                { .content = "   ", .style = ants::Style::Default },
-                { .content = "C++", .style = ants::Style::custom(2) },
+                { /*content=*/"   ", /*style=*/ants::Style::Default },
+                { /*content=*/"Helloorld", /*style=*/ants::Style::Highlight },
+                { /*content=*/"   ", /*style=*/ants::Style::Default },
+                { /*content=*/"C++", /*style=*/ants::Style::custom(2) },
             } })
         );
         // clang-format on
@@ -484,8 +486,9 @@ TEST(StyledStringTest, SetStyledContent) {
 
     {
         auto str = ants::StyledString();
-        auto const content = ants::StyledString::styled("Hello World", ants::Style::Highlight)
-                                 .with_style(ants::Style::Auto, 6);
+        auto const content =  //
+            ants::StyledString::styled("Hello World", ants::Style::Highlight)
+                .with_style(ants::Style::Auto, 6);
 
         str.set_styled_content(5, content.styled_line_parts().front());
         EXPECT_EQ(str.content(), "     Hello World");
@@ -493,9 +496,9 @@ TEST(StyledStringTest, SetStyledContent) {
         EXPECT_EQ(
             str.styled_line_parts(),
             (LineParts { {
-                { .content = "     ", .style = ants::Style::Default },
-                { .content = "Hello ", .style = ants::Style::Highlight },
-                { .content = "World", .style = ants::Style::Auto },
+                { /*content=*/"     ", /*style=*/ants::Style::Default },
+                { /*content=*/"Hello ", /*style=*/ants::Style::Highlight },
+                { /*content=*/"World", /*style=*/ants::Style::Auto },
             } })
         );
         // clang-format on
@@ -506,11 +509,11 @@ TEST(StyledStringTest, SetStyledContent) {
         EXPECT_EQ(
             str.styled_line_parts(),
             (LineParts { {
-                { .content = "     ", .style = ants::Style::Default },
-                { .content = "Hello ", .style = ants::Style::Highlight },
-                { .content = "W", .style = ants::Style::Auto },
-                { .content = "Hello ", .style = ants::Style::Highlight },
-                { .content = "World", .style = ants::Style::Auto },
+                { /*content=*/"     ", /*style=*/ants::Style::Default },
+                { /*content=*/"Hello ", /*style=*/ants::Style::Highlight },
+                { /*content=*/"W", /*style=*/ants::Style::Auto },
+                { /*content=*/"Hello ", /*style=*/ants::Style::Highlight },
+                { /*content=*/"World", /*style=*/ants::Style::Auto },
             } })
         );
         // clang-format on
@@ -521,11 +524,11 @@ TEST(StyledStringTest, SetStyledContent) {
         EXPECT_EQ(
             str.styled_line_parts(),
             (LineParts { {
-                { .content = "  ", .style = ants::Style::Default },
-                { .content = "Hello ", .style = ants::Style::Highlight },
-                { .content = "World", .style = ants::Style::Auto },
-                { .content = "ello ", .style = ants::Style::Highlight },
-                { .content = "World", .style = ants::Style::Auto },
+                { /*content=*/"  ", /*style=*/ants::Style::Default },
+                { /*content=*/"Hello ", /*style=*/ants::Style::Highlight },
+                { /*content=*/"World", /*style=*/ants::Style::Auto },
+                { /*content=*/"ello ", /*style=*/ants::Style::Highlight },
+                { /*content=*/"World", /*style=*/ants::Style::Auto },
             } })
         );
         // clang-format on
@@ -536,11 +539,11 @@ TEST(StyledStringTest, SetStyledContent) {
         EXPECT_EQ(
             str.styled_line_parts(),
             (LineParts { {
-                { .content = "  ", .style = ants::Style::Default },
-                { .content = "Hello ", .style = ants::Style::Highlight },
-                { .content = "World", .style = ants::Style::Addition },
-                { .content = "ello ", .style = ants::Style::Highlight },
-                { .content = "World", .style = ants::Style::Auto },
+                { /*content=*/"  ", /*style=*/ants::Style::Default },
+                { /*content=*/"Hello ", /*style=*/ants::Style::Highlight },
+                { /*content=*/"World", /*style=*/ants::Style::Addition },
+                { /*content=*/"ello ", /*style=*/ants::Style::Highlight },
+                { /*content=*/"World", /*style=*/ants::Style::Auto },
             } })
         );
         // clang-format on
@@ -551,11 +554,11 @@ TEST(StyledStringTest, SetStyledContent) {
         EXPECT_EQ(
             str.styled_line_parts(),
             (LineParts { {
-                { .content = "  ", .style = ants::Style::Default },
-                { .content = "Hello ", .style = ants::Style::Highlight },
-                { .content = "World", .style = ants::Style::Addition },
-                { .content = "ello ", .style = ants::Style::Highlight },
-                { .content = "World", .style = ants::Style::Auto },
+                { /*content=*/"  ", /*style=*/ants::Style::Default },
+                { /*content=*/"Hello ", /*style=*/ants::Style::Highlight },
+                { /*content=*/"World", /*style=*/ants::Style::Addition },
+                { /*content=*/"ello ", /*style=*/ants::Style::Highlight },
+                { /*content=*/"World", /*style=*/ants::Style::Auto },
             } })
         );
         // clang-format on
@@ -565,45 +568,45 @@ TEST(StyledStringTest, SetStyledContent) {
 TEST(StyledStringTest, Constructor) {
     {
         auto const str = ants::StyledString::inferred("abc");
-        LineParts const expected { { { .content = "abc", .style = ants::Style::Auto } } };
+        LineParts const expected { { { /*content=*/"abc", /*style=*/ants::Style::Auto } } };
         EXPECT_EQ(str.styled_line_parts(), expected);
     }
 
     {
         auto const str = ants::StyledString::plain("abc");
-        LineParts const expected { { { .content = "abc", .style = ants::Style::Default } } };
+        LineParts const expected { { { /*content=*/"abc", /*style=*/ants::Style::Default } } };
         EXPECT_EQ(str.styled_line_parts(), expected);
     }
 
     {
         auto const str = ants::StyledString::styled("abc", ants::Style::Highlight);
-        LineParts const expected { { { .content = "abc", .style = ants::Style::Highlight } } };
+        LineParts const expected { { { /*content=*/"abc", /*style=*/ants::Style::Highlight } } };
         EXPECT_EQ(str.styled_line_parts(), expected);
     }
 
     {
         auto const str = ants::StyledString::styled("abc", ants::Style::custom(1));
         auto const lines = str.styled_line_parts();
-        LineParts const expected { { { .content = "abc", .style = ants::Style::custom(1) } } };
+        LineParts const expected { { { /*content=*/"abc", /*style=*/ants::Style::custom(1) } } };
         EXPECT_EQ(lines, expected);
         EXPECT_NE(lines.front().front().style, ants::Style::Default);
     }
 
     {
         ants::StyledString const str = "abc";
-        LineParts const expected { { { .content = "abc", .style = ants::Style::Auto } } };
+        LineParts const expected { { { /*content=*/"abc", /*style=*/ants::Style::Auto } } };
         EXPECT_EQ(str.styled_line_parts(), expected);
     }
 
     {
         ants::StyledString const str("abc");
-        LineParts const expected { { { .content = "abc", .style = ants::Style::Auto } } };
+        LineParts const expected { { { /*content=*/"abc", /*style=*/ants::Style::Auto } } };
         EXPECT_EQ(str.styled_line_parts(), expected);
     }
 
     {
         ants::StyledString const str(std::string_view("abc"));
-        LineParts const expected { { { .content = "abc", .style = ants::Style::Auto } } };
+        LineParts const expected { { { /*content=*/"abc", /*style=*/ants::Style::Auto } } };
         EXPECT_EQ(str.styled_line_parts(), expected);
     }
 }

--- a/test/styled_string_view_test.cpp
+++ b/test/styled_string_view_test.cpp
@@ -12,7 +12,7 @@ using LineParts = std::vector<std::vector<ants::StyledStringViewPart>>;
 TEST(StyledStringViewTest, SingleLineWithStyle) {
     {
         auto const lines = ants::StyledStringView::inferred("abcdefg").styled_line_parts();
-        LineParts const expected { { { .content = "abcdefg", .style = ants::Style::Auto } } };
+        LineParts const expected { { { /*content=*/"abcdefg", /*style=*/ants::Style::Auto } } };
         EXPECT_EQ(lines, expected);
     }
 
@@ -29,243 +29,261 @@ TEST(StyledStringViewTest, SingleLineWithStyle) {
     }
 
     {
-        auto const lines = ants::StyledStringView::inferred("abcdefg")
-                               .with_style(ants::Style::Auto, 2, 4)
-                               .styled_line_parts();
-        LineParts const expected { { { .content = "abcdefg", .style = ants::Style::Auto } } };
+        auto const lines =  //
+            ants::StyledStringView::inferred("abcdefg")
+                .with_style(ants::Style::Auto, 2, 4)
+                .styled_line_parts();
+        LineParts const expected { { { /*content=*/"abcdefg", /*style=*/ants::Style::Auto } } };
         EXPECT_EQ(lines, expected);
     }
 
     {
-        auto const lines = ants::StyledStringView::inferred("abcdefg")
-                               .with_style(ants::Style::Default, 0, 7)
-                               .styled_line_parts();
-        LineParts const expected { { { .content = "abcdefg", .style = ants::Style::Default } } };
+        auto const lines =  //
+            ants::StyledStringView::inferred("abcdefg")
+                .with_style(ants::Style::Default, 0, 7)
+                .styled_line_parts();
+        LineParts const expected { { { /*content=*/"abcdefg", /*style=*/ants::Style::Default } } };
         EXPECT_EQ(lines, expected);
     }
 
     {
-        auto const lines = ants::StyledStringView::inferred("abcdefg")
-                               .with_style(ants::Style::Default, 0, 3)
-                               .styled_line_parts();
+        auto const lines =  //
+            ants::StyledStringView::inferred("abcdefg")
+                .with_style(ants::Style::Default, 0, 3)
+                .styled_line_parts();
         // clang-format off
         LineParts const expected { {
-            { .content = "abc", .style = ants::Style::Default },
-            { .content = "defg", .style = ants::Style::Auto },
+            { /*content=*/"abc", /*style=*/ants::Style::Default },
+            { /*content=*/"defg", /*style=*/ants::Style::Auto },
         } };
         // clang-format on
         EXPECT_EQ(lines, expected);
     }
 
     {
-        auto const lines = ants::StyledStringView::inferred("abcdefg")
-                               .with_style(ants::Style::Default, 0, 3)
-                               .with_style(ants::Style::Default, 3, 7)
-                               .styled_line_parts();
-        LineParts const expected { { { .content = "abcdefg", .style = ants::Style::Default } } };
+        auto const lines =  //
+            ants::StyledStringView::inferred("abcdefg")
+                .with_style(ants::Style::Default, 0, 3)
+                .with_style(ants::Style::Default, 3, 7)
+                .styled_line_parts();
+        LineParts const expected { { { /*content=*/"abcdefg", /*style=*/ants::Style::Default } } };
         EXPECT_EQ(lines, expected);
     }
 
     {
-        auto const lines = ants::StyledStringView::inferred("abcdefg")
-                               .with_style(ants::Style::Default, 0, 3)
-                               .with_style(ants::Style::Default, 2, 7)
-                               .styled_line_parts();
-        LineParts const expected { { { .content = "abcdefg", .style = ants::Style::Default } } };
+        auto const lines =  //
+            ants::StyledStringView::inferred("abcdefg")
+                .with_style(ants::Style::Default, 0, 3)
+                .with_style(ants::Style::Default, 2, 7)
+                .styled_line_parts();
+        LineParts const expected { { { /*content=*/"abcdefg", /*style=*/ants::Style::Default } } };
         EXPECT_EQ(lines, expected);
     }
 
     {
-        auto const lines = ants::StyledStringView::inferred("abcdefg")
-                               .with_style(ants::Style::Default, 3, 7)
-                               .styled_line_parts();
+        auto const lines =  //
+            ants::StyledStringView::inferred("abcdefg")
+                .with_style(ants::Style::Default, 3, 7)
+                .styled_line_parts();
         // clang-format off
         LineParts const expected { {
-            { .content = "abc", .style = ants::Style::Auto },
-            { .content = "defg", .style = ants::Style::Default },
+            { /*content=*/"abc", /*style=*/ants::Style::Auto },
+            { /*content=*/"defg", /*style=*/ants::Style::Default },
         } };
         // clang-format on
         EXPECT_EQ(lines, expected);
     }
 
     {
-        auto const lines = ants::StyledStringView::inferred("abcdefg")
-                               .with_style(ants::Style::Default, 3, 7)
-                               .with_style(ants::Style::Default, 2, 3)
-                               .styled_line_parts();
+        auto const lines =  //
+            ants::StyledStringView::inferred("abcdefg")
+                .with_style(ants::Style::Default, 3, 7)
+                .with_style(ants::Style::Default, 2, 3)
+                .styled_line_parts();
         // clang-format off
         LineParts const expected { {
-            { .content = "ab", .style = ants::Style::Auto },
-            { .content = "cdefg", .style = ants::Style::Default },
+            { /*content=*/"ab", /*style=*/ants::Style::Auto },
+            { /*content=*/"cdefg", /*style=*/ants::Style::Default },
         } };
         // clang-format on
         EXPECT_EQ(lines, expected);
     }
 
     {
-        auto const lines = ants::StyledStringView::inferred("abcdefg")
-                               .with_style(ants::Style::Default, 2, 5)
-                               .styled_line_parts();
+        auto const lines =  //
+            ants::StyledStringView::inferred("abcdefg")
+                .with_style(ants::Style::Default, 2, 5)
+                .styled_line_parts();
         // clang-format off
         LineParts const expected { {
-            { .content = "ab", .style = ants::Style::Auto },
-            { .content = "cde", .style = ants::Style::Default },
-            { .content = "fg", .style = ants::Style::Auto },
+            { /*content=*/"ab", /*style=*/ants::Style::Auto },
+            { /*content=*/"cde", /*style=*/ants::Style::Default },
+            { /*content=*/"fg", /*style=*/ants::Style::Auto },
         } };
         // clang-format on
         EXPECT_EQ(lines, expected);
     }
 
     {
-        auto const lines = ants::StyledStringView::inferred("abcdefg")
-                               .with_style(ants::Style::Default, 0, 3)
-                               .with_style(ants::Style::Highlight, 5, 7)
-                               .styled_line_parts();
+        auto const lines =  //
+            ants::StyledStringView::inferred("abcdefg")
+                .with_style(ants::Style::Default, 0, 3)
+                .with_style(ants::Style::Highlight, 5, 7)
+                .styled_line_parts();
         // clang-format off
         LineParts const expected { {
-            { .content = "abc", .style = ants::Style::Default },
-            { .content = "de", .style = ants::Style::Auto },
-            { .content = "fg", .style = ants::Style::Highlight },
+            { /*content=*/"abc", /*style=*/ants::Style::Default },
+            { /*content=*/"de", /*style=*/ants::Style::Auto },
+            { /*content=*/"fg", /*style=*/ants::Style::Highlight },
         } };
         // clang-format on
         EXPECT_EQ(lines, expected);
     }
 
     {
-        auto const lines = ants::StyledStringView::inferred("abcdefg")
-                               .with_style(ants::Style::Default, 0, 3)
-                               .with_style(ants::Style::Highlight, 5, 7)
-                               .with_style(ants::Style::Highlight, 2, 5)
-                               .styled_line_parts();
+        auto const lines =  //
+            ants::StyledStringView::inferred("abcdefg")
+                .with_style(ants::Style::Default, 0, 3)
+                .with_style(ants::Style::Highlight, 5, 7)
+                .with_style(ants::Style::Highlight, 2, 5)
+                .styled_line_parts();
         // clang-format off
         LineParts const expected { {
-            { .content = "ab", .style = ants::Style::Default },
-            { .content = "cdefg", .style = ants::Style::Highlight },
+            { /*content=*/"ab", /*style=*/ants::Style::Default },
+            { /*content=*/"cdefg", /*style=*/ants::Style::Highlight },
         } };
         // clang-format on
         EXPECT_EQ(lines, expected);
     }
 
     {
-        auto const lines = ants::StyledStringView::inferred("abcdefg")
-                               .with_style(ants::Style::Default, 0, 3)
-                               .with_style(ants::Style::Highlight, 5, 7)
-                               .with_style(ants::Style::Highlight, 3, 5)
-                               .styled_line_parts();
+        auto const lines =  //
+            ants::StyledStringView::inferred("abcdefg")
+                .with_style(ants::Style::Default, 0, 3)
+                .with_style(ants::Style::Highlight, 5, 7)
+                .with_style(ants::Style::Highlight, 3, 5)
+                .styled_line_parts();
         // clang-format off
         LineParts const expected { {
-            { .content = "abc", .style = ants::Style::Default },
-            { .content = "defg", .style = ants::Style::Highlight },
+            { /*content=*/"abc", /*style=*/ants::Style::Default },
+            { /*content=*/"defg", /*style=*/ants::Style::Highlight },
         } };
         // clang-format on
         EXPECT_EQ(lines, expected);
     }
 
     {
-        auto const lines = ants::StyledStringView::inferred("abcdefg")
-                               .with_style(ants::Style::Default, 0, 3)
-                               .with_style(ants::Style::Highlight, 5, 7)
-                               .with_style(ants::Style::Highlight, 0, 3)
-                               .styled_line_parts();
+        auto const lines =  //
+            ants::StyledStringView::inferred("abcdefg")
+                .with_style(ants::Style::Default, 0, 3)
+                .with_style(ants::Style::Highlight, 5, 7)
+                .with_style(ants::Style::Highlight, 0, 3)
+                .styled_line_parts();
         // clang-format off
         LineParts const expected { {
-            { .content = "abc", .style = ants::Style::Highlight },
-            { .content = "de", .style = ants::Style::Auto },
-            { .content = "fg", .style = ants::Style::Highlight },
+            { /*content=*/"abc", /*style=*/ants::Style::Highlight },
+            { /*content=*/"de", /*style=*/ants::Style::Auto },
+            { /*content=*/"fg", /*style=*/ants::Style::Highlight },
         } };
         // clang-format on
         EXPECT_EQ(lines, expected);
     }
 
     {
-        auto const lines = ants::StyledStringView::inferred("abcdefg")
-                               .with_style(ants::Style::Default, 0, 3)
-                               .with_style(ants::Style::Highlight, 4, 7)
-                               .with_style(ants::Style::PrimaryTitle, 2, 5)
-                               .styled_line_parts();
+        auto const lines =  //
+            ants::StyledStringView::inferred("abcdefg")
+                .with_style(ants::Style::Default, 0, 3)
+                .with_style(ants::Style::Highlight, 4, 7)
+                .with_style(ants::Style::PrimaryTitle, 2, 5)
+                .styled_line_parts();
         // clang-format off
         LineParts const expected { {
-            { .content = "ab", .style = ants::Style::Default },
-            { .content = "cde", .style = ants::Style::PrimaryTitle },
-            { .content = "fg", .style = ants::Style::Highlight },
+            { /*content=*/"ab", /*style=*/ants::Style::Default },
+            { /*content=*/"cde", /*style=*/ants::Style::PrimaryTitle },
+            { /*content=*/"fg", /*style=*/ants::Style::Highlight },
         } };
         // clang-format on
         EXPECT_EQ(lines, expected);
     }
 
     {
-        auto const lines = ants::StyledStringView::inferred("abcdefg")
-                               .with_style(ants::Style::Default, 0, 3)
-                               .with_style(ants::Style::Highlight, 4, 7)
-                               .with_style(ants::Style::PrimaryTitle, 2, 7)
-                               .styled_line_parts();
+        auto const lines =  //
+            ants::StyledStringView::inferred("abcdefg")
+                .with_style(ants::Style::Default, 0, 3)
+                .with_style(ants::Style::Highlight, 4, 7)
+                .with_style(ants::Style::PrimaryTitle, 2, 7)
+                .styled_line_parts();
         // clang-format off
         LineParts const expected { {
-            { .content = "ab", .style = ants::Style::Default },
-            { .content = "cdefg", .style = ants::Style::PrimaryTitle },
+            { /*content=*/"ab", /*style=*/ants::Style::Default },
+            { /*content=*/"cdefg", /*style=*/ants::Style::PrimaryTitle },
         } };
         // clang-format on
         EXPECT_EQ(lines, expected);
     }
 
     {
-        auto const lines = ants::StyledStringView::inferred("abcdefg")
-                               .with_style(ants::Style::Default, 0, 3)
-                               .with_style(ants::Style::Highlight, 4, 7)
-                               .with_style(ants::Style::PrimaryTitle, 0, 5)
-                               .styled_line_parts();
+        auto const lines =  //
+            ants::StyledStringView::inferred("abcdefg")
+                .with_style(ants::Style::Default, 0, 3)
+                .with_style(ants::Style::Highlight, 4, 7)
+                .with_style(ants::Style::PrimaryTitle, 0, 5)
+                .styled_line_parts();
         // clang-format off
         LineParts const expected { {
-            { .content = "abcde", .style = ants::Style::PrimaryTitle },
-            { .content = "fg", .style = ants::Style::Highlight },
+            { /*content=*/"abcde", /*style=*/ants::Style::PrimaryTitle },
+            { /*content=*/"fg", /*style=*/ants::Style::Highlight },
         } };
         // clang-format on
         EXPECT_EQ(lines, expected);
     }
 
     {
-        auto const lines = ants::StyledStringView::inferred("abcdefg")
-                               .with_style(ants::Style::Default, 0, 3)
-                               .with_style(ants::Style::Highlight, 4, 7)
-                               .with_style(ants::Style::PrimaryTitle, 0, 4)
-                               .styled_line_parts();
+        auto const lines =  //
+            ants::StyledStringView::inferred("abcdefg")
+                .with_style(ants::Style::Default, 0, 3)
+                .with_style(ants::Style::Highlight, 4, 7)
+                .with_style(ants::Style::PrimaryTitle, 0, 4)
+                .styled_line_parts();
         // clang-format off
         LineParts const expected { {
-            { .content = "abcd", .style = ants::Style::PrimaryTitle },
-            { .content = "efg", .style = ants::Style::Highlight },
+            { /*content=*/"abcd", /*style=*/ants::Style::PrimaryTitle },
+            { /*content=*/"efg", /*style=*/ants::Style::Highlight },
         } };
         // clang-format on
         EXPECT_EQ(lines, expected);
     }
 
     {
-        auto const lines = ants::StyledStringView::inferred("abcdefg")
-                               .with_style(ants::Style::Default, 0, 3)
-                               .with_style(ants::Style::Highlight, 4, 7)
-                               .with_style(ants::Style::PrimaryTitle, 0, 3)
-                               .styled_line_parts();
+        auto const lines =  //
+            ants::StyledStringView::inferred("abcdefg")
+                .with_style(ants::Style::Default, 0, 3)
+                .with_style(ants::Style::Highlight, 4, 7)
+                .with_style(ants::Style::PrimaryTitle, 0, 3)
+                .styled_line_parts();
         // clang-format off
         LineParts const expected { {
-            { .content = "abc", .style = ants::Style::PrimaryTitle },
-            { .content = "d", .style = ants::Style::Auto },
-            { .content = "efg", .style = ants::Style::Highlight },
+            { /*content=*/"abc", /*style=*/ants::Style::PrimaryTitle },
+            { /*content=*/"d", /*style=*/ants::Style::Auto },
+            { /*content=*/"efg", /*style=*/ants::Style::Highlight },
         } };
         // clang-format on
         EXPECT_EQ(lines, expected);
     }
 
     {
-        auto const lines = ants::StyledStringView::inferred("abcdefg")
-                               .with_style(ants::Style::Default, 0, 3)
-                               .with_style(ants::Style::Highlight, 4, 7)
-                               .with_style(ants::Style::PrimaryTitle, 0, 1)
-                               .styled_line_parts();
+        auto const lines =  //
+            ants::StyledStringView::inferred("abcdefg")
+                .with_style(ants::Style::Default, 0, 3)
+                .with_style(ants::Style::Highlight, 4, 7)
+                .with_style(ants::Style::PrimaryTitle, 0, 1)
+                .styled_line_parts();
         // clang-format off
         LineParts const expected { {
-            { .content = "a", .style = ants::Style::PrimaryTitle },
-            { .content = "bc", .style = ants::Style::Default },
-            { .content = "d", .style = ants::Style::Auto },
-            { .content = "efg", .style = ants::Style::Highlight },
+            { /*content=*/"a", /*style=*/ants::Style::PrimaryTitle },
+            { /*content=*/"bc", /*style=*/ants::Style::Default },
+            { /*content=*/"d", /*style=*/ants::Style::Auto },
+            { /*content=*/"efg", /*style=*/ants::Style::Highlight },
         } };
         // clang-format on
         EXPECT_EQ(lines, expected);
@@ -275,37 +293,39 @@ TEST(StyledStringViewTest, SingleLineWithStyle) {
 TEST(StyledStringViewTest, MultiLineWithStyle) {
     {
         auto const lines = ants::StyledStringView::inferred("abcdefg\n").styled_line_parts();
-        LineParts const expected { { { .content = "abcdefg", .style = ants::Style::Auto } } };
+        LineParts const expected { { { /*content=*/"abcdefg", /*style=*/ants::Style::Auto } } };
         EXPECT_EQ(lines, expected);
     }
 
     {
-        auto const lines = ants::StyledStringView::inferred("abcdefg\n")
-                               .with_style(ants::Style::Default, 0, 7)
-                               .styled_line_parts();
-        LineParts const expected { { { .content = "abcdefg", .style = ants::Style::Default } } };
+        auto const lines =  //
+            ants::StyledStringView::inferred("abcdefg\n")
+                .with_style(ants::Style::Default, 0, 7)
+                .styled_line_parts();
+        LineParts const expected { { { /*content=*/"abcdefg", /*style=*/ants::Style::Default } } };
         EXPECT_EQ(lines, expected);
     }
 
     {
         auto const lines = ants::StyledStringView::inferred("abcdefg\r\n").styled_line_parts();
-        LineParts const expected { { { .content = "abcdefg", .style = ants::Style::Auto } } };
+        LineParts const expected { { { /*content=*/"abcdefg", /*style=*/ants::Style::Auto } } };
         EXPECT_EQ(lines, expected);
     }
 
     {
-        auto const lines = ants::StyledStringView::inferred("abcdefg\r\n")
-                               .with_style(ants::Style::Default, 0, 7)
-                               .styled_line_parts();
-        LineParts const expected { { { .content = "abcdefg", .style = ants::Style::Default } } };
+        auto const lines =  //
+            ants::StyledStringView::inferred("abcdefg\r\n")
+                .with_style(ants::Style::Default, 0, 7)
+                .styled_line_parts();
+        LineParts const expected { { { /*content=*/"abcdefg", /*style=*/ants::Style::Default } } };
         EXPECT_EQ(lines, expected);
     }
 
     {
         auto const lines = ants::StyledStringView::inferred("abcdefg\n\n").styled_line_parts();
         LineParts const expected {
-            { { .content = "abcdefg", .style = ants::Style::Auto } },
-            { { .content = "", .style = ants::Style::Auto } },
+            { { /*content=*/"abcdefg", /*style=*/ants::Style::Auto } },
+            { { /*content=*/"", /*style=*/ants::Style::Auto } },
         };
         EXPECT_EQ(lines, expected);
     }
@@ -313,8 +333,8 @@ TEST(StyledStringViewTest, MultiLineWithStyle) {
     {
         auto const lines = ants::StyledStringView::inferred("\nabcdefg").styled_line_parts();
         LineParts const expected {
-            { { .content = "", .style = ants::Style::Auto } },
-            { { .content = "abcdefg", .style = ants::Style::Auto } },
+            { { /*content=*/"", /*style=*/ants::Style::Auto } },
+            { { /*content=*/"abcdefg", /*style=*/ants::Style::Auto } },
         };
         EXPECT_EQ(lines, expected);
     }
@@ -322,9 +342,9 @@ TEST(StyledStringViewTest, MultiLineWithStyle) {
     {
         auto const lines = ants::StyledStringView::inferred("abc\ndef\ng").styled_line_parts();
         LineParts const expected {
-            { { .content = "abc", .style = ants::Style::Auto } },
-            { { .content = "def", .style = ants::Style::Auto } },
-            { { .content = "g", .style = ants::Style::Auto } },
+            { { /*content=*/"abc", /*style=*/ants::Style::Auto } },
+            { { /*content=*/"def", /*style=*/ants::Style::Auto } },
+            { { /*content=*/"g", /*style=*/ants::Style::Auto } },
         };
         EXPECT_EQ(lines, expected);
     }
@@ -332,9 +352,9 @@ TEST(StyledStringViewTest, MultiLineWithStyle) {
     {
         auto const lines = ants::StyledStringView::inferred("abc\r\ndef\ng").styled_line_parts();
         LineParts const expected {
-            { { .content = "abc", .style = ants::Style::Auto } },
-            { { .content = "def", .style = ants::Style::Auto } },
-            { { .content = "g", .style = ants::Style::Auto } },
+            { { /*content=*/"abc", /*style=*/ants::Style::Auto } },
+            { { /*content=*/"def", /*style=*/ants::Style::Auto } },
+            { { /*content=*/"g", /*style=*/ants::Style::Auto } },
         };
         EXPECT_EQ(lines, expected);
     }
@@ -342,9 +362,9 @@ TEST(StyledStringViewTest, MultiLineWithStyle) {
     {
         auto const lines = ants::StyledStringView::inferred("abc\ndef\ng\n").styled_line_parts();
         LineParts const expected {
-            { { .content = "abc", .style = ants::Style::Auto } },
-            { { .content = "def", .style = ants::Style::Auto } },
-            { { .content = "g", .style = ants::Style::Auto } },
+            { { /*content=*/"abc", /*style=*/ants::Style::Auto } },
+            { { /*content=*/"def", /*style=*/ants::Style::Auto } },
+            { { /*content=*/"g", /*style=*/ants::Style::Auto } },
         };
         EXPECT_EQ(lines, expected);
     }
@@ -352,9 +372,9 @@ TEST(StyledStringViewTest, MultiLineWithStyle) {
     {
         auto const lines = ants::StyledStringView::inferred("ab\rc\ndef\ng").styled_line_parts();
         LineParts const expected {
-            { { .content = "ab\rc", .style = ants::Style::Auto } },
-            { { .content = "def", .style = ants::Style::Auto } },
-            { { .content = "g", .style = ants::Style::Auto } },
+            { { /*content=*/"ab\rc", /*style=*/ants::Style::Auto } },
+            { { /*content=*/"def", /*style=*/ants::Style::Auto } },
+            { { /*content=*/"g", /*style=*/ants::Style::Auto } },
         };
         EXPECT_EQ(lines, expected);
     }
@@ -363,192 +383,205 @@ TEST(StyledStringViewTest, MultiLineWithStyle) {
         auto const lines =
             ants::StyledStringView::inferred("abc\ndef\r\n\r\ng").styled_line_parts();
         LineParts const expected {
-            { { .content = "abc", .style = ants::Style::Auto } },
-            { { .content = "def", .style = ants::Style::Auto } },
-            { { .content = "", .style = ants::Style::Auto } },
-            { { .content = "g", .style = ants::Style::Auto } },
+            { { /*content=*/"abc", /*style=*/ants::Style::Auto } },
+            { { /*content=*/"def", /*style=*/ants::Style::Auto } },
+            { { /*content=*/"", /*style=*/ants::Style::Auto } },
+            { { /*content=*/"g", /*style=*/ants::Style::Auto } },
         };
         EXPECT_EQ(lines, expected);
     }
 
     {
-        auto const lines = ants::StyledStringView::inferred("abc\ndef\ng")
-                               .with_style(ants::Style::Default, 0, 2)
-                               .styled_line_parts();
+        auto const lines =  //
+            ants::StyledStringView::inferred("abc\ndef\ng")
+                .with_style(ants::Style::Default, 0, 2)
+                .styled_line_parts();
         // clang-format off
         LineParts const expected {
-            { { .content = "ab", .style = ants::Style::Default },
-              { .content = "c", .style = ants::Style::Auto } },
-            { { .content = "def", .style = ants::Style::Auto } },
-            { { .content = "g", .style = ants::Style::Auto } },
+            { { /*content=*/"ab", /*style=*/ants::Style::Default },
+              { /*content=*/"c", /*style=*/ants::Style::Auto } },
+            { { /*content=*/"def", /*style=*/ants::Style::Auto } },
+            { { /*content=*/"g", /*style=*/ants::Style::Auto } },
         };
         // clang-format on
         EXPECT_EQ(lines, expected);
     }
 
     {
-        auto const lines = ants::StyledStringView::inferred("abc\ndef\ng")
-                               .with_style(ants::Style::Default, 0, 3)
-                               .styled_line_parts();
+        auto const lines =  //
+            ants::StyledStringView::inferred("abc\ndef\ng")
+                .with_style(ants::Style::Default, 0, 3)
+                .styled_line_parts();
         LineParts const expected {
-            { { .content = "abc", .style = ants::Style::Default } },
-            { { .content = "def", .style = ants::Style::Auto } },
-            { { .content = "g", .style = ants::Style::Auto } },
+            { { /*content=*/"abc", /*style=*/ants::Style::Default } },
+            { { /*content=*/"def", /*style=*/ants::Style::Auto } },
+            { { /*content=*/"g", /*style=*/ants::Style::Auto } },
         };
         EXPECT_EQ(lines, expected);
     }
 
     {
-        auto const lines = ants::StyledStringView::inferred("abc\ndef\ng")
-                               .with_style(ants::Style::Default, 0, 4)
-                               .styled_line_parts();
+        auto const lines =  //
+            ants::StyledStringView::inferred("abc\ndef\ng")
+                .with_style(ants::Style::Default, 0, 4)
+                .styled_line_parts();
         LineParts const expected {
-            { { .content = "abc", .style = ants::Style::Default } },
-            { { .content = "def", .style = ants::Style::Auto } },
-            { { .content = "g", .style = ants::Style::Auto } },
+            { { /*content=*/"abc", /*style=*/ants::Style::Default } },
+            { { /*content=*/"def", /*style=*/ants::Style::Auto } },
+            { { /*content=*/"g", /*style=*/ants::Style::Auto } },
         };
         EXPECT_EQ(lines, expected);
     }
 
     {
-        auto const lines = ants::StyledStringView::inferred("abc\ndef\ng")
-                               .with_style(ants::Style::Default, 0, 5)
-                               .styled_line_parts();
+        auto const lines =  //
+            ants::StyledStringView::inferred("abc\ndef\ng")
+                .with_style(ants::Style::Default, 0, 5)
+                .styled_line_parts();
         // clang-format off
         LineParts const expected {
-            { { .content = "abc", .style = ants::Style::Default } },
-            { { .content = "d", .style = ants::Style::Default },
-              { .content = "ef", .style = ants::Style::Auto } },
-            { { .content = "g", .style = ants::Style::Auto } },
+            { { /*content=*/"abc", /*style=*/ants::Style::Default } },
+            { { /*content=*/"d", /*style=*/ants::Style::Default },
+              { /*content=*/"ef", /*style=*/ants::Style::Auto } },
+            { { /*content=*/"g", /*style=*/ants::Style::Auto } },
         };
         // clang-format on
         EXPECT_EQ(lines, expected);
     }
 
     {
-        auto const lines = ants::StyledStringView::inferred("abc\ndef\ng")
-                               .with_style(ants::Style::Default, 2, 5)
-                               .styled_line_parts();
+        auto const lines =  //
+            ants::StyledStringView::inferred("abc\ndef\ng")
+                .with_style(ants::Style::Default, 2, 5)
+                .styled_line_parts();
         // clang-format off
         LineParts const expected {
-            { { .content = "ab", .style = ants::Style::Auto },
-              { .content = "c", .style = ants::Style::Default } },
-            { { .content = "d", .style = ants::Style::Default },
-              { .content = "ef", .style = ants::Style::Auto } },
-            { { .content = "g", .style = ants::Style::Auto } },
+            { { /*content=*/"ab", /*style=*/ants::Style::Auto },
+              { /*content=*/"c", /*style=*/ants::Style::Default } },
+            { { /*content=*/"d", /*style=*/ants::Style::Default },
+              { /*content=*/"ef", /*style=*/ants::Style::Auto } },
+            { { /*content=*/"g", /*style=*/ants::Style::Auto } },
         };
         // clang-format on
         EXPECT_EQ(lines, expected);
     }
 
     {
-        auto const lines = ants::StyledStringView::inferred("abc\ndef\ng")
-                               .with_style(ants::Style::Default, 3, 5)
-                               .styled_line_parts();
+        auto const lines =  //
+            ants::StyledStringView::inferred("abc\ndef\ng")
+                .with_style(ants::Style::Default, 3, 5)
+                .styled_line_parts();
         // clang-format off
         LineParts const expected {
-            { { .content = "abc", .style = ants::Style::Auto } },
-            { { .content = "d", .style = ants::Style::Default },
-              { .content = "ef", .style = ants::Style::Auto } },
-            { { .content = "g", .style = ants::Style::Auto } },
+            { { /*content=*/"abc", /*style=*/ants::Style::Auto } },
+            { { /*content=*/"d", /*style=*/ants::Style::Default },
+              { /*content=*/"ef", /*style=*/ants::Style::Auto } },
+            { { /*content=*/"g", /*style=*/ants::Style::Auto } },
         };
         // clang-format on
         EXPECT_EQ(lines, expected);
     }
 
     {
-        auto const lines = ants::StyledStringView::inferred("abc\ndef\ng")
-                               .with_style(ants::Style::Default, 4, 5)
-                               .styled_line_parts();
+        auto const lines =  //
+            ants::StyledStringView::inferred("abc\ndef\ng")
+                .with_style(ants::Style::Default, 4, 5)
+                .styled_line_parts();
         // clang-format off
         LineParts const expected {
-            { { .content = "abc", .style = ants::Style::Auto } },
-            { { .content = "d", .style = ants::Style::Default },
-              { .content = "ef", .style = ants::Style::Auto } },
-            { { .content = "g", .style = ants::Style::Auto } },
+            { { /*content=*/"abc", /*style=*/ants::Style::Auto } },
+            { { /*content=*/"d", /*style=*/ants::Style::Default },
+              { /*content=*/"ef", /*style=*/ants::Style::Auto } },
+            { { /*content=*/"g", /*style=*/ants::Style::Auto } },
         };
         // clang-format on
         EXPECT_EQ(lines, expected);
     }
 
     {
-        auto const lines = ants::StyledStringView::inferred("abc\ndef\ng")
-                               .with_style(ants::Style::Default, 3, 8)
-                               .styled_line_parts();
+        auto const lines =  //
+            ants::StyledStringView::inferred("abc\ndef\ng")
+                .with_style(ants::Style::Default, 3, 8)
+                .styled_line_parts();
         LineParts const expected {
-            { { .content = "abc", .style = ants::Style::Auto } },
-            { { .content = "def", .style = ants::Style::Default } },
-            { { .content = "g", .style = ants::Style::Auto } },
+            { { /*content=*/"abc", /*style=*/ants::Style::Auto } },
+            { { /*content=*/"def", /*style=*/ants::Style::Default } },
+            { { /*content=*/"g", /*style=*/ants::Style::Auto } },
         };
         EXPECT_EQ(lines, expected);
     }
 
     {
-        auto const lines = ants::StyledStringView::inferred("abc\ndef\ng")
-                               .with_style(ants::Style::Default, 4, 8)
-                               .styled_line_parts();
+        auto const lines =  //
+            ants::StyledStringView::inferred("abc\ndef\ng")
+                .with_style(ants::Style::Default, 4, 8)
+                .styled_line_parts();
         LineParts const expected {
-            { { .content = "abc", .style = ants::Style::Auto } },
-            { { .content = "def", .style = ants::Style::Default } },
-            { { .content = "g", .style = ants::Style::Auto } },
+            { { /*content=*/"abc", /*style=*/ants::Style::Auto } },
+            { { /*content=*/"def", /*style=*/ants::Style::Default } },
+            { { /*content=*/"g", /*style=*/ants::Style::Auto } },
         };
         EXPECT_EQ(lines, expected);
     }
 
     {
-        auto const lines = ants::StyledStringView::inferred("abc\ndef\ng")
-                               .with_style(ants::Style::Default, 3, 7)
-                               .styled_line_parts();
+        auto const lines =  //
+            ants::StyledStringView::inferred("abc\ndef\ng")
+                .with_style(ants::Style::Default, 3, 7)
+                .styled_line_parts();
         LineParts const expected {
-            { { .content = "abc", .style = ants::Style::Auto } },
-            { { .content = "def", .style = ants::Style::Default } },
-            { { .content = "g", .style = ants::Style::Auto } },
+            { { /*content=*/"abc", /*style=*/ants::Style::Auto } },
+            { { /*content=*/"def", /*style=*/ants::Style::Default } },
+            { { /*content=*/"g", /*style=*/ants::Style::Auto } },
         };
         EXPECT_EQ(lines, expected);
     }
 
     {
-        auto const lines = ants::StyledStringView::inferred("abc\ndef\ng")
-                               .with_style(ants::Style::Default, 4, 7)
-                               .styled_line_parts();
+        auto const lines =  //
+            ants::StyledStringView::inferred("abc\ndef\ng")
+                .with_style(ants::Style::Default, 4, 7)
+                .styled_line_parts();
         LineParts const expected {
-            { { .content = "abc", .style = ants::Style::Auto } },
-            { { .content = "def", .style = ants::Style::Default } },
-            { { .content = "g", .style = ants::Style::Auto } },
+            { { /*content=*/"abc", /*style=*/ants::Style::Auto } },
+            { { /*content=*/"def", /*style=*/ants::Style::Default } },
+            { { /*content=*/"g", /*style=*/ants::Style::Auto } },
         };
         EXPECT_EQ(lines, expected);
     }
 
     {
-        auto const lines = ants::StyledStringView::inferred("ab\r\nc\nde\nfgh\r\ni")
-                               .with_style(ants::Style::Default, 2, 10)
-                               .styled_line_parts();
+        auto const lines =  //
+            ants::StyledStringView::inferred("ab\r\nc\nde\nfgh\r\ni")
+                .with_style(ants::Style::Default, 2, 10)
+                .styled_line_parts();
         // clang-format off
         LineParts const expected {
-            { { .content = "ab", .style = ants::Style::Auto } },
-            { { .content = "c", .style = ants::Style::Default } },
-            { { .content = "de", .style = ants::Style::Default } },
-            { { .content = "f", .style = ants::Style::Default },
-              { .content = "gh", .style = ants::Style::Auto } },
-            { { .content = "i", .style = ants::Style::Auto } },
+            { { /*content=*/"ab", /*style=*/ants::Style::Auto } },
+            { { /*content=*/"c", /*style=*/ants::Style::Default } },
+            { { /*content=*/"de", /*style=*/ants::Style::Default } },
+            { { /*content=*/"f", /*style=*/ants::Style::Default },
+              { /*content=*/"gh", /*style=*/ants::Style::Auto } },
+            { { /*content=*/"i", /*style=*/ants::Style::Auto } },
         };
         // clang-format on
         EXPECT_EQ(lines, expected);
     }
 
     {
-        auto const lines = ants::StyledStringView::inferred("ab\r\nc\nde\nfgh\r\ni")
-                               .with_style(ants::Style::Default, 1, 10)
-                               .styled_line_parts();
+        auto const lines =  //
+            ants::StyledStringView::inferred("ab\r\nc\nde\nfgh\r\ni")
+                .with_style(ants::Style::Default, 1, 10)
+                .styled_line_parts();
         // clang-format off
         LineParts const expected {
-            { { .content = "a", .style = ants::Style::Auto },
-              { .content = "b", .style = ants::Style::Default } },
-            { { .content = "c", .style = ants::Style::Default } },
-            { { .content = "de", .style = ants::Style::Default } },
-            { { .content = "f", .style = ants::Style::Default },
-              { .content = "gh", .style = ants::Style::Auto } },
-            { { .content = "i", .style = ants::Style::Auto } },
+            { { /*content=*/"a", /*style=*/ants::Style::Auto },
+              { /*content=*/"b", /*style=*/ants::Style::Default } },
+            { { /*content=*/"c", /*style=*/ants::Style::Default } },
+            { { /*content=*/"de", /*style=*/ants::Style::Default } },
+            { { /*content=*/"f", /*style=*/ants::Style::Default },
+              { /*content=*/"gh", /*style=*/ants::Style::Auto } },
+            { { /*content=*/"i", /*style=*/ants::Style::Auto } },
         };
         // clang-format on
         EXPECT_EQ(lines, expected);
@@ -558,46 +591,46 @@ TEST(StyledStringViewTest, MultiLineWithStyle) {
 TEST(StyledStringViewTest, Constructor) {
     {
         auto const lines = ants::StyledStringView::inferred("abc").styled_line_parts();
-        LineParts const expected { { { .content = "abc", .style = ants::Style::Auto } } };
+        LineParts const expected { { { /*content=*/"abc", /*style=*/ants::Style::Auto } } };
         EXPECT_EQ(lines, expected);
     }
 
     {
         auto const lines = ants::StyledStringView::plain("abc").styled_line_parts();
-        LineParts const expected { { { .content = "abc", .style = ants::Style::Default } } };
+        LineParts const expected { { { /*content=*/"abc", /*style=*/ants::Style::Default } } };
         EXPECT_EQ(lines, expected);
     }
 
     {
         auto const lines =
             ants::StyledStringView::styled("abc", ants::Style::Highlight).styled_line_parts();
-        LineParts const expected { { { .content = "abc", .style = ants::Style::Highlight } } };
+        LineParts const expected { { { /*content=*/"abc", /*style=*/ants::Style::Highlight } } };
         EXPECT_EQ(lines, expected);
     }
 
     {
         auto const lines =
             ants::StyledStringView::styled("abc", ants::Style::custom(1)).styled_line_parts();
-        LineParts const expected { { { .content = "abc", .style = ants::Style::custom(1) } } };
+        LineParts const expected { { { /*content=*/"abc", /*style=*/ants::Style::custom(1) } } };
         EXPECT_EQ(lines, expected);
         EXPECT_NE(lines.front().front().style, ants::Style::Default);
     }
 
     {
         ants::StyledStringView const str = "abc";
-        LineParts const expected { { { .content = "abc", .style = ants::Style::Auto } } };
+        LineParts const expected { { { /*content=*/"abc", /*style=*/ants::Style::Auto } } };
         EXPECT_EQ(str.styled_line_parts(), expected);
     }
 
     {
         ants::StyledStringView const str("abc");
-        LineParts const expected { { { .content = "abc", .style = ants::Style::Auto } } };
+        LineParts const expected { { { /*content=*/"abc", /*style=*/ants::Style::Auto } } };
         EXPECT_EQ(str.styled_line_parts(), expected);
     }
 
     {
         ants::StyledStringView const str(std::string_view("abc"));
-        LineParts const expected { { { .content = "abc", .style = ants::Style::Auto } } };
+        LineParts const expected { { { /*content=*/"abc", /*style=*/ants::Style::Auto } } };
         EXPECT_EQ(str.styled_line_parts(), expected);
     }
 }
@@ -605,18 +638,18 @@ TEST(StyledStringViewTest, Constructor) {
 TEST(StyledStringViewTest, Setter) {
     {
         auto view = ants::StyledStringView::inferred("abcd");
-        LineParts expected { { { .content = "abcd", .style = ants::Style::Auto } } };
+        LineParts expected { { { /*content=*/"abcd", /*style=*/ants::Style::Auto } } };
         EXPECT_EQ(view.styled_line_parts(), expected);
 
         view.set_style(ants::Style::Default);
-        expected = { { { .content = "abcd", .style = ants::Style::Default } } };
+        expected = { { { /*content=*/"abcd", /*style=*/ants::Style::Default } } };
         EXPECT_EQ(view.styled_line_parts(), expected);
 
         view.set_style(ants::Style::Highlight, 3);
         // clang-format off
         expected = { {
-            { .content = "abc", .style = ants::Style::Default },
-            { .content = "d", .style = ants::Style::Highlight },
+            { /*content=*/"abc", /*style=*/ants::Style::Default },
+            { /*content=*/"d", /*style=*/ants::Style::Highlight },
         } };
         // clang-format on
         EXPECT_EQ(view.styled_line_parts(), expected);
@@ -624,10 +657,10 @@ TEST(StyledStringViewTest, Setter) {
         view.set_style(ants::Style::PrimaryUnderline, 1, 2);
         // clang-format off
         expected = { {
-            { .content = "a", .style = ants::Style::Default },
-            { .content = "b", .style = ants::Style::PrimaryUnderline },
-            { .content = "c", .style = ants::Style::Default },
-            { .content = "d", .style = ants::Style::Highlight },
+            { /*content=*/"a", /*style=*/ants::Style::Default },
+            { /*content=*/"b", /*style=*/ants::Style::PrimaryUnderline },
+            { /*content=*/"c", /*style=*/ants::Style::Default },
+            { /*content=*/"d", /*style=*/ants::Style::Highlight },
         } };
         // clang-format on
         EXPECT_EQ(view.styled_line_parts(), expected);
@@ -635,25 +668,25 @@ TEST(StyledStringViewTest, Setter) {
         view.set_style(ants::Style::custom(3), 1, 2);
         // clang-format off
         expected = { {
-            { .content = "a", .style = ants::Style::Default },
-            { .content = "b", .style = ants::Style::custom(3) },
-            { .content = "c", .style = ants::Style::Default },
-            { .content = "d", .style = ants::Style::Highlight },
+            { /*content=*/"a", /*style=*/ants::Style::Default },
+            { /*content=*/"b", /*style=*/ants::Style::custom(3) },
+            { /*content=*/"c", /*style=*/ants::Style::Default },
+            { /*content=*/"d", /*style=*/ants::Style::Highlight },
         } };
         // clang-format on
         EXPECT_EQ(view.styled_line_parts(), expected);
 
         view.set_style(ants::Style::custom(1));
         view.set_style(ants::Style::custom(2), 2, 2);
-        expected = { { { .content = "abcd", .style = ants::Style::custom(1) } } };
+        expected = { { { /*content=*/"abcd", /*style=*/ants::Style::custom(1) } } };
         EXPECT_EQ(view.styled_line_parts(), expected);
 
         view.set_style(ants::Style::custom(2), 2);
         view.set_style(ants::Style::custom(3), 2, 2);
         // clang-format off
         expected = { {
-            { .content = "ab", .style = ants::Style::custom(1) },
-            { .content = "cd", .style = ants::Style::custom(2) },
+            { /*content=*/"ab", /*style=*/ants::Style::custom(1) },
+            { /*content=*/"cd", /*style=*/ants::Style::custom(2) },
         } };
         // clang-format on
         EXPECT_EQ(view.styled_line_parts(), expected);


### PR DESCRIPTION
This PR lowers the required C++ standard for the project from C++23 to C++17. The main changes include:
- Removed usage of C++20 and C++23 features, such as:
  - ranges and views
  - concepts
  - `std::span`
  - designated initializers
- Refactored code to maintain equivalent functionality using C++17-compatible constructs.
- Updated CI scripts to ensure compatibility with a broader range of compilers that support C++17.
- Improved and standardized comments.