### PR TITLE
[CI] Update Windows build matrix to remove deprecated OS version.

### DIFF
--- a/.github/workflows/gtest.yml
+++ b/.github/workflows/gtest.yml
@@ -114,7 +114,7 @@ jobs:
     strategy:
       matrix:
         build_type: [ Debug, Release ]
-        os: [ windows-2019, windows-2022, windows-2025 ]
+        os: [ windows-2022, windows-2025 ]
 
     name: Build and Test on Windows
     runs-on: ${{matrix.os}}


### PR DESCRIPTION
Windows 2019 will be deprecated: https://github.com/actions/runner-images/issues/12045