### PR TITLE
Enable maximum warning level for the unit test target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,11 +50,12 @@ target_include_directories(annotate_snippets
         $<BUILD_INTERFACE:${rang_SOURCE_DIR}/include>
 )
 
-target_compile_options(annotate_snippets
-    PRIVATE
-        $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wall -Wextra -Wpedantic -Werror>
-        $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
+set(
+    ANTS_WARNING_OPTIONS
+    $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wall -Wextra -Wpedantic -Werror>
+    $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
 )
+target_compile_options(annotate_snippets PRIVATE ${ANTS_WARNING_OPTIONS})
 
 target_compile_features(annotate_snippets PUBLIC cxx_std_17)
 

--- a/include/annotate_snippets/renderer/human_renderer.hpp
+++ b/include/annotate_snippets/renderer/human_renderer.hpp
@@ -396,10 +396,6 @@ private:
             return static_cast<unsigned>(anonymized_line_num.size());
         }
 
-        auto const source_trans = [&](AnnotatedSource& source) {
-            return compute_max_line_num_len(source);
-        };
-
         unsigned result = 0;
 
         // Primary diag entry.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,4 +22,5 @@ add_executable(annotate_snippets_tests
     renderer/human_renderer_test/render_suggestion.cpp
 )
 target_link_libraries(annotate_snippets_tests PRIVATE annotate_snippets gtest_main)
+target_compile_options(annotate_snippets_tests PRIVATE ${ANTS_WARNING_OPTIONS})
 gtest_discover_tests(annotate_snippets_tests)

--- a/test/source_file_test.cpp
+++ b/test/source_file_test.cpp
@@ -579,7 +579,7 @@ void check_adjust_empty_span(SourceFile& source, SourceLocation loc) {
     SCOPED_TRACE(message);
 
     // Call `adjust_span()` to adjust the empty span.
-    LabeledSpan const span = source.adjust_span(LabeledSpan { loc, loc });
+    LabeledSpan const span = source.adjust_span(LabeledSpan { loc, loc, {} });
     EXPECT_TRUE(span.beg.is_fully_specified());
     EXPECT_TRUE(span.end.is_fully_specified());
     EXPECT_EQ(span.beg.line(), loc.line());
@@ -588,7 +588,7 @@ void check_adjust_empty_span(SourceFile& source, SourceLocation loc) {
     EXPECT_EQ(span.end.col(), loc.col() + 1);
 
     // Use the fully specified location to test again to check that no assertion is triggered.
-    LabeledSpan const span2 = source.adjust_span(LabeledSpan { span.beg, span.beg });
+    LabeledSpan const span2 = source.adjust_span(LabeledSpan { span.beg, span.beg, {} });
     EXPECT_TRUE(span2.beg.is_fully_specified());
     EXPECT_TRUE(span2.end.is_fully_specified());
     EXPECT_EQ(span2.beg, span.beg);
@@ -607,14 +607,14 @@ void check_adjust_span_end(SourceFile& source, SourceLocation end, SourceLocatio
     SCOPED_TRACE(message);
 
     // Call `adjust_span()` to adjust the span with only `end` specified.
-    LabeledSpan const span = source.adjust_span(LabeledSpan { SourceLocation(0, 0), end });
+    LabeledSpan const span = source.adjust_span(LabeledSpan { SourceLocation(0, 0), end, {} });
     EXPECT_TRUE(span.beg.is_fully_specified());
     EXPECT_TRUE(span.end.is_fully_specified());
     EXPECT_EQ(span.end.line(), expected_end.line());
     EXPECT_EQ(span.end.col(), expected_end.col());
 
     // Use the fully specified location to test again to check that no assertion is triggered.
-    LabeledSpan const span2 = source.adjust_span(LabeledSpan { span.beg, span.end });
+    LabeledSpan const span2 = source.adjust_span(LabeledSpan { span.beg, span.end, {} });
     EXPECT_TRUE(span2.beg.is_fully_specified());
     EXPECT_TRUE(span2.end.is_fully_specified());
     EXPECT_EQ(span2.beg, span.beg);


### PR DESCRIPTION
This PR enables the maximum warning level for the `annotate_snippets_tests` target. Many warnings from templates in headers are only emitted when the templates are instantiated, so they can only be caught if the unit tests that instantiate them also build with the maximum warning level. This helps prevent such warnings from leaking into downstream builds.